### PR TITLE
feat: add Rust toolchain setup via rustup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ During installation, you'll be prompted to choose between two installation metho
   - Node.js: Uses nvm for version management. Also installs yarn and TypeScript.
   - Bun: JavaScript runtime and toolkit (alternative to Node.js).
   - Go: Installs Go directly from the official website.
+  - Rust: Uses rustup for toolchain management (rustc, cargo, clippy, rustfmt).
 
 - **Docker Support**: Optional installation of Docker and Docker Compose
 
@@ -67,6 +68,10 @@ source ~/.bashrc
 
 # For Go development
 ./tools/setup_golang.sh
+source ~/.bashrc
+
+# For Rust development
+./tools/setup_rust.sh
 source ~/.bashrc
 ```
 
@@ -154,6 +159,12 @@ bun --version  # Should display Bun version
 ./tools/setup_golang.sh
 source ~/.bashrc
 go version  # Should display Go version
+
+# Test Rust setup
+./tools/setup_rust.sh
+source ~/.bashrc
+rustc --version  # Should display Rust version
+cargo --version  # Should display Cargo version
 ```
 
 ### Verifying Tool Configurations
@@ -171,6 +182,7 @@ echo $PATH | grep nvm
 echo $PATH | grep ".bun/bin"        # Check for Bun
 echo $PATH | grep "/usr/local/go/bin" # Check for Go
 echo $PATH | grep "$HOME/go/bin"    # Check for Go's GOPATH bin
+echo $PATH | grep ".cargo/bin"      # Check for Rust/Cargo
 
 # Try installing a specific version of a tool
 sdk install java 17.0.8-tem
@@ -238,13 +250,15 @@ dotfiles/
 │       ├── python.sh       # uv configuration
 │       ├── node.sh         # nvm configuration
 │       ├── golang.sh       # Go configuration
-│       └── bun.sh          # Bun configuration
+│       ├── bun.sh          # Bun configuration
+│       └── rust.sh         # Rust/Cargo configuration
 ├── tools/                  # Setup scripts for development tools
 │   ├── setup_java.sh       # Installs SDKMAN and Java
 │   ├── setup_python.sh     # Installs uv and Python
 │   ├── setup_node.sh       # Installs nvm and Node.js
 │   ├── setup_golang.sh     # Installs Go
-│   └── setup_bun.sh        # Installs Bun
+│   ├── setup_bun.sh        # Installs Bun
+│   └── setup_rust.sh       # Installs Rust via rustup
 ├── test/                   # Docker-based testing environment
 │   ├── Dockerfile          # Test container definition
 │   ├── docker-compose.yml  # Container orchestration

--- a/bash/tool_configs/rust.sh
+++ b/bash/tool_configs/rust.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Rust configuration (rustup + cargo)
+
+export CARGO_HOME="$HOME/.cargo"
+export RUSTUP_HOME="$HOME/.rustup"
+
+# Add cargo bin to PATH
+[ -d "$CARGO_HOME/bin" ] && export PATH="$CARGO_HOME/bin:$PATH"
+
+# Enable shell completions for cargo and rustup
+if command -v rustup &> /dev/null; then
+    eval "$(rustup completions bash 2>/dev/null || true)"
+    eval "$(rustup completions bash cargo 2>/dev/null || true)"
+fi

--- a/install.sh
+++ b/install.sh
@@ -181,6 +181,11 @@ install_dev_tools() {
         bash "$DOTFILES_DIR/tools/setup_golang.sh"
     fi
 
+    # Install Rust
+    if confirm "Do you want to install Rust?"; then
+        bash "$DOTFILES_DIR/tools/setup_rust.sh"
+    fi
+
     # Install Neovim with LazyVim
     if confirm "Do you want to install Neovim with LazyVim?"; then
         bash "$DOTFILES_DIR/tools/setup_nvim.sh"
@@ -198,6 +203,7 @@ else
     log_kv "Node.js" "./tools/setup_node.sh"
     log_kv "Bun" "./tools/setup_bun.sh"
     log_kv "Go" "./tools/setup_golang.sh"
+    log_kv "Rust" "./tools/setup_rust.sh"
     log_kv "Neovim" "./tools/setup_nvim.sh"
 fi
 

--- a/tools/setup_rust.sh
+++ b/tools/setup_rust.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Install Rust via rustup
+# rustup manages Rust toolchains (rustc, cargo, clippy, rustfmt)
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$DOTFILES_DIR/tools/common.sh"
+
+log_header "Rust Setup (rustup)"
+
+log_section "Installing Rust"
+
+if command -v rustup &> /dev/null; then
+    log_info "Rust is already installed, checking for updates..."
+    rustup update stable 2>/dev/null || true
+    log_success "Rust updated"
+else
+    log_step 1 "Installing Rust via rustup..."
+    # Install with --no-modify-path since PATH is managed by tool_configs/rust.sh
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+
+    # Add to PATH for this session
+    export PATH="$HOME/.cargo/bin:$PATH"
+    log_success "Rust installed"
+
+    log_detail "Note: PATH is managed by ~/.tool_configs/rust.sh"
+fi
+
+# Verify installation
+if ! command -v rustc &> /dev/null; then
+    die "Rust installation failed"
+fi
+
+log_success "rustc $(rustc --version | awk '{print $2}') ready"
+
+log_section "Setup Complete"
+log_info "Quick reference:"
+log_kv "rustup update" "Update Rust toolchain"
+log_kv "rustup component add" "Add components (e.g., rust-analyzer)"
+log_kv "cargo new" "Create a new project"
+log_kv "cargo build" "Build the project"
+log_kv "cargo run" "Build and run"
+log_kv "cargo test" "Run tests"


### PR DESCRIPTION
Add tool_config and install script for Rust, following the same conventions as other tools. Uses --no-modify-path to keep PATH management in tool_configs/rust.sh instead of letting rustup modify shell profiles directly.