### PR TITLE
Fix latent bugs: extract() quoting, LD_LIBRARY_PATH, nvim config overwrite

### DIFF
--- a/bash/bash_functions
+++ b/bash/bash_functions
@@ -8,30 +8,38 @@ mkcd() {
 
 # Extract various archive formats to a folder with the same name
 extract() {
-    if [ -f $1 ] ; then
-        # Get filename without extension
-        local dirname=$(basename "$1" | sed 's/\.[^.]*$//')
-        mkdir -p "$dirname" && cd "$dirname"
-        
-        case $1 in
-            *.tar.bz2)   tar xjf ../$1     ;;
-            *.tar.gz)    tar xzf ../$1     ;;
-            *.bz2)       bunzip2 ../$1     ;;
-            *.rar)       unrar e ../$1     ;;
-            *.gz)        gunzip ../$1      ;;
-            *.tar)       tar xf ../$1      ;;
-            *.tbz2)      tar xjf ../$1     ;;
-            *.tgz)       tar xzf ../$1     ;;
-            *.zip)       unzip ../$1       ;;
-            *.Z)         uncompress ../$1  ;;
-            *.7z)        7z x ../$1        ;;
-            *)           echo "'$1' cannot be extracted via extract()" ;;
-        esac
-        
-        cd ..
-    else
+    if [ ! -f "$1" ]; then
         echo "'$1' is not a valid file"
+        return 1
     fi
+
+    # Strip multi-part extensions properly (.tar.gz, .tar.bz2, etc.)
+    local base
+    base=$(basename "$1")
+    case "$base" in
+        *.tar.bz2|*.tar.gz|*.tar.xz) base="${base%.*.*}" ;;
+        *)                            base="${base%.*}"    ;;
+    esac
+
+    mkdir -p "$base" && cd "$base" || return 1
+
+    case "$1" in
+        *.tar.bz2)   tar xjf "../$1"     ;;
+        *.tar.gz)    tar xzf "../$1"     ;;
+        *.tar.xz)    tar xJf "../$1"     ;;
+        *.bz2)       bunzip2 "../$1"     ;;
+        *.rar)       unrar e "../$1"     ;;
+        *.gz)        gunzip "../$1"      ;;
+        *.tar)       tar xf "../$1"      ;;
+        *.tbz2)      tar xjf "../$1"     ;;
+        *.tgz)       tar xzf "../$1"     ;;
+        *.zip)       unzip "../$1"       ;;
+        *.Z)         uncompress "../$1"  ;;
+        *.7z)        7z x "../$1"        ;;
+        *)           echo "'$1' cannot be extracted via extract()" ;;
+    esac
+
+    cd ..
 }
 
 # Create a backup of a file with date

--- a/bash/bash_paths
+++ b/bash/bash_paths
@@ -12,7 +12,7 @@
 
 # CUDA (for gitnexus)
 [ -d "/usr/local/cuda-12.6/bin" ] && export PATH="/usr/local/cuda-12.6/bin:$PATH"
-[ -d "/usr/local/cuda-12.6/lib64" ] && export LD_LIBRARY_PATH="/usr/local/cuda-12.6/lib64:$LD_LIBRARY_PATH"
+[ -d "/usr/local/cuda-12.6/lib64" ] && export LD_LIBRARY_PATH="/usr/local/cuda-12.6/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 # Google Cloud SDK
 [ -f "$HOME/google-cloud-sdk/path.bash.inc" ] && source "$HOME/google-cloud-sdk/path.bash.inc"

--- a/tools/setup_nvim.sh
+++ b/tools/setup_nvim.sh
@@ -67,19 +67,19 @@ if ! sudo make install >/dev/null; then
 fi
 
 # --- Configuration Setup ---
-log_step "Creating Neovim tool config file..."
+log_step "Verifying Neovim tool config..."
 mkdir -p "$TOOL_CONFIG_DIR"
-cat >"$TOOL_CONFIG_FILE" <<EOF
-#!/usr/bin/env bash
-# Neovim configuration (managed by dotfiles setup)
 
-# Add Neovim to the PATH
-export PATH="$INSTALL_PREFIX/bin:\$PATH"
-
-# Aliases for Neovim
-alias vi="nvim"
-alias vim="nvim"
-EOF
+# If the tool config is a symlink (from install.sh symlink mode), leave it alone.
+# The version-controlled bash/tool_configs/nvim.sh is the source of truth.
+if [ -L "$TOOL_CONFIG_FILE" ]; then
+    log_info "Tool config is symlinked — using version-controlled config"
+elif [ -f "$DOTFILES_DIR/bash/tool_configs/nvim.sh" ]; then
+    cp "$DOTFILES_DIR/bash/tool_configs/nvim.sh" "$TOOL_CONFIG_FILE"
+    log_success "Copied tool config to $TOOL_CONFIG_FILE"
+else
+    log_warn "No nvim.sh tool config found in dotfiles repo"
+fi
 
 # --- User Config Backup & Symlink ---
 if [ -e "$NEOVIM_CONFIG_DIR" ] || [ -L "$NEOVIM_CONFIG_DIR" ]; then


### PR DESCRIPTION
## Summary
- Fix `extract()`: quote all variables, handle `.tar.gz`/`.tar.bz2` extensions correctly, add `.tar.xz`
- Fix `LD_LIBRARY_PATH` trailing colon when variable is unset (security concern)
- Fix `setup_nvim.sh` overwriting symlinked tool config (data loss on version-controlled file)

## Test plan
- [ ] Run `extract "file with spaces.tar.gz"` — should work without errors
- [ ] Unset `LD_LIBRARY_PATH`, source `bash_paths`, verify no trailing colon in value
- [ ] Run `install.sh` (symlink mode), then `setup_nvim.sh` — verify `bash/tool_configs/nvim.sh` in repo is unchanged

## Merge order
Merge PR #6 first, then this PR.