### PR TITLE
Quality improvements: PATH dedup, Go portability, Docker Compose, SSH hardening

### DIFF
--- a/bash/tool_configs/nvim.sh
+++ b/bash/tool_configs/nvim.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # Neovim configuration (managed by dotfiles setup)
 
-# Add Neovim to the PATH (needed if installed to /usr/local, which is what we are doing when we build neovim from source)
-export PATH="/usr/local/bin:$PATH"
+# /usr/local/bin is already in the default PATH on all standard Unix systems
 
 # Aliases for Neovim
 alias vi="nvim"

--- a/bash/tool_configs/python.sh
+++ b/bash/tool_configs/python.sh
@@ -2,10 +2,7 @@
 # Python configuration with uv
 # uv handles Python versions, virtual environments, and package management
 
-# Add uv and uv-managed tools to PATH
-if [ -d "$HOME/.local/bin" ]; then
-    export PATH="$HOME/.local/bin:$PATH"
-fi
+# Note: $HOME/.local/bin is added in bash_paths — no need to duplicate here
 
 # Enable uv shell completion (optional, improves tab completion)
 if command -v uv &> /dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -132,15 +132,17 @@ if command -v apt-get &> /dev/null; then
             fi
         fi
         
-        # Install Docker Compose if not already installed
-        if ! command -v docker-compose &> /dev/null; then
-            if confirm "Do you want to install Docker Compose?"; then
-                # TODO: Don't pin docker-compose version
-                log_step 3 "Installing Docker Compose..."
-                sudo curl -L "https://github.com/docker/compose/releases/download/v2.20.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                sudo chmod +x /usr/local/bin/docker-compose
-                log_success "Docker Compose installed"
+        # Docker Compose - modern Docker ships with 'docker compose' as a plugin
+        if docker compose version &> /dev/null; then
+            log_success "Docker Compose plugin already available: $(docker compose version --short)"
+        elif ! command -v docker-compose &> /dev/null; then
+            if confirm "Do you want to install the Docker Compose plugin?"; then
+                log_step 3 "Installing Docker Compose plugin..."
+                sudo apt-get install -y docker-compose-plugin
+                log_success "Docker Compose plugin installed"
             fi
+        else
+            log_info "Legacy docker-compose found: $(docker-compose --version)"
         fi
     fi
 fi

--- a/tools/setup_git.sh
+++ b/tools/setup_git.sh
@@ -99,16 +99,25 @@ if [ ! -f "$ssh_key" ]; then
         
         # Test SSH connection to common Git hosts
         log_step 3 "Testing SSH connections..."
-        
+
+        # Add known host keys if not already present (avoids StrictHostKeyChecking=no)
+        mkdir -p "$ssh_dir"
+        if ! grep -q "^github.com " "$ssh_dir/known_hosts" 2>/dev/null; then
+            ssh-keyscan -t ed25519 github.com >> "$ssh_dir/known_hosts" 2>/dev/null
+        fi
+        if ! grep -q "^gitlab.com " "$ssh_dir/known_hosts" 2>/dev/null; then
+            ssh-keyscan -t ed25519 gitlab.com >> "$ssh_dir/known_hosts" 2>/dev/null
+        fi
+
         # Test GitHub
-        if ssh -T git@github.com -o ConnectTimeout=5 -o StrictHostKeyChecking=no 2>&1 | grep -q "successfully authenticated"; then
+        if ssh -T git@github.com -o ConnectTimeout=5 2>&1 | grep -q "successfully authenticated"; then
             log_success "GitHub SSH connection successful"
         else
             log_warn "GitHub SSH connection failed (this is normal if you haven't added the key yet)"
         fi
-        
+
         # Test GitLab
-        if ssh -T git@gitlab.com -o ConnectTimeout=5 -o StrictHostKeyChecking=no 2>&1 | grep -q "Welcome to GitLab"; then
+        if ssh -T git@gitlab.com -o ConnectTimeout=5 2>&1 | grep -q "Welcome to GitLab"; then
             log_success "GitLab SSH connection successful"
         else
             log_warn "GitLab SSH connection failed (this is normal if you haven't added the key yet)"

--- a/tools/setup_golang.sh
+++ b/tools/setup_golang.sh
@@ -7,65 +7,63 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$DOTFILES_DIR/tools/common.sh"
 
-GO_VERSION="1.22.3"
 INSTALL_DIR="/usr/local"
-GO_ARCHIVE="go${GO_VERSION}.linux-amd64.tar.gz"
-DOWNLOAD_URL="https://golang.org/dl/${GO_ARCHIVE}"
 
 log_header "Go Setup"
 
-log_step 1 "Checking for existing Go installation..."
+# --- Detect architecture ---
+log_step 1 "Detecting system architecture..."
+case "$(uname -m)" in
+    x86_64)  ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+    armv7l)  ARCH="armv6l" ;;
+    *)       die "Unsupported architecture: $(uname -m)" ;;
+esac
+
+case "$(uname -s)" in
+    Linux)  OS="linux" ;;
+    Darwin) OS="darwin" ;;
+    *)      die "Unsupported OS: $(uname -s)" ;;
+esac
+log_detail "Detected: ${OS}/${ARCH}"
+
+# --- Fetch latest stable version ---
+log_step 2 "Checking for latest Go version..."
+GO_VERSION=$(curl -sL 'https://go.dev/VERSION?m=text' | head -1 | sed 's/^go//')
+if [ -z "$GO_VERSION" ]; then
+    die "Could not determine latest Go version. Check your internet connection."
+fi
+log_detail "Latest stable: ${GO_VERSION}"
+
+# --- Check existing installation ---
 if [ -d "${INSTALL_DIR}/go" ] && [ -x "${INSTALL_DIR}/go/bin/go" ]; then
     CURRENT_VERSION=$(${INSTALL_DIR}/go/bin/go version | awk '{print $3}' | sed 's/go//')
     if [ "${CURRENT_VERSION}" == "${GO_VERSION}" ]; then
-        log_info "Go version ${GO_VERSION} is already installed."
+        log_info "Go ${GO_VERSION} is already installed."
         exit 0
     else
-        log_warn "Found existing Go version ${CURRENT_VERSION}. Removing it before installing ${GO_VERSION}..."
+        log_warn "Found Go ${CURRENT_VERSION}. Upgrading to ${GO_VERSION}..."
         sudo rm -rf "${INSTALL_DIR}/go"
     fi
 fi
 
-log_step 2 "Installing Go version ${GO_VERSION}..."
+# --- Download to temp directory ---
+GO_ARCHIVE="go${GO_VERSION}.${OS}-${ARCH}.tar.gz"
+DOWNLOAD_URL="https://go.dev/dl/${GO_ARCHIVE}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
 
-# Check for dependencies
-log_detail "Checking for curl..."
-if ! command -v curl &> /dev/null; then
-    log_warn "curl is not installed. Attempting to install..."
-    if command -v apt-get &> /dev/null; then
-        sudo apt-get update
-        sudo apt-get install -y curl
-        if ! command -v curl &> /dev/null; then
-            die "Failed to install curl. Please install it manually."
-        fi
-    else
-        die "curl is not installed and apt-get is not available."
-    fi
-fi
+log_step 3 "Installing Go ${GO_VERSION}..."
 
-log_detail "Downloading Go ${GO_VERSION}..."
-curl -LO "${DOWNLOAD_URL}"
+log_detail "Downloading ${GO_ARCHIVE}..."
+curl -fsSL "${DOWNLOAD_URL}" -o "${TMPDIR}/${GO_ARCHIVE}"
 
-if [ ! -f "${GO_ARCHIVE}" ]; then
-    die "Failed to download Go archive. Please check the URL or your internet connection."
-fi
-
-log_step 3 "Extracting Go archive to ${INSTALL_DIR}..."
-sudo tar -C "${INSTALL_DIR}" -xzf "${GO_ARCHIVE}"
+log_detail "Extracting to ${INSTALL_DIR}..."
+sudo tar -C "${INSTALL_DIR}" -xzf "${TMPDIR}/${GO_ARCHIVE}"
 
 if [ ! -d "${INSTALL_DIR}/go" ]; then
-    rm -f "${GO_ARCHIVE}"
     die "Failed to extract Go. Check permissions and available space."
 fi
 
-log_detail "Cleaning up downloaded archive..."
-rm -f "${GO_ARCHIVE}"
-
-log_success "Go ${GO_VERSION} installation complete."
-log_info "Please add the following to your shell configuration file (e.g., ~/.bashrc, ~/.zshrc):"
-log_separator
-echo "export GOROOT=${INSTALL_DIR}/go"
-echo "export GOPATH=\$HOME/go"
-echo "export PATH=\$PATH:\$GOROOT/bin:\$GOPATH/bin"
-log_separator
-log_info "Then, source your configuration file or open a new terminal."
+log_success "Go ${GO_VERSION} (${OS}/${ARCH}) installed."
+log_info "PATH is managed by ~/.tool_configs/golang.sh"


### PR DESCRIPTION
## Summary
- Remove duplicate `$HOME/.local/bin` and pointless `/usr/local/bin` PATH additions
- Go setup: detect architecture (amd64/arm64), fetch latest version dynamically, download to temp dir
- Docker Compose: use plugin (`docker compose`) instead of deprecated standalone binary
- SSH setup: use `ssh-keyscan` to pin host keys instead of `StrictHostKeyChecking=no`

## Test plan
- [x] Source bashrc, verify `echo $PATH` has no duplicate entries for `.local/bin`
- [x] Review `setup_golang.sh` — verify `uname -m` mapping is correct for your machine
- [x] Run `docker compose version` after fresh Docker install — verify plugin detected
- [x] Run `setup_git.sh` SSH test — verify `~/.ssh/known_hosts` has github.com entry, no `-o StrictHostKeyChecking=no` in commands

## Merge order
Merge after PR #7.