### PR TITLE
Pin Go and golangci-lint versions

### DIFF
--- a/docs/superpowers/plans/2026-03-21-ci-install-test.md
+++ b/docs/superpowers/plans/2026-03-21-ci-install-test.md
@@ -1,0 +1,209 @@
+# CI Install Test Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add GitHub Actions CI that runs the Docker-based install test on every PR, with a non-interactive mode for `confirm()`.
+
+**Architecture:** A single env var `DOTFILES_CI=1` makes `confirm()` auto-accept defaults. `test/run-test.sh` uses plain `docker build`/`run` to install everything and run smoke tests. The GitHub Actions workflow just calls `run-test.sh`.
+
+**Tech Stack:** Bash, Docker, GitHub Actions
+
+**Spec:** `docs/superpowers/specs/2026-03-21-ci-install-test-design.md`
+
+---
+
+### Task 1: Add non-interactive flag to `confirm()`
+
+**Files:**
+- Modify: `bash/bash_logger:184-192`
+
+- [ ] **Step 1: Add CI guard to `confirm()`**
+
+Insert one line after the `local` declarations, before the `hint` line:
+
+```bash
+[[ "${DOTFILES_CI:-}" == "1" ]] && return $([[ "$default" == "y" ]] && echo 0 || echo 1)
+```
+
+The full function becomes:
+
+```bash
+confirm() {
+    local prompt="${1:-Continue?}" default="${2:-y}"
+    [[ "${DOTFILES_CI:-}" == "1" ]] && return $([[ "$default" == "y" ]] && echo 0 || echo 1)
+    local hint=$([[ "$default" == "y" ]] && echo "Y/n" || echo "y/N")
+
+    echo -en "${_C_YELLOW}${_S_LINE} ${_S_WARN}  ${prompt} [${hint}] ${_C_RESET}"
+    read -r response < /dev/tty
+    [[ -z "$response" ]] && response="$default"
+    [[ "$response" =~ ^[Yy]$ ]]
+}
+```
+
+- [ ] **Step 2: Verify the change works**
+
+Run from the repo root:
+
+```bash
+# Should return 0 (success) — default is "y"
+DOTFILES_CI=1 bash -c 'source bash/bash_logger; confirm "test?" "y"; echo $?'
+# Expected output: 0
+
+# Should return 1 (failure) — default is "n"
+DOTFILES_CI=1 bash -c 'source bash/bash_logger; confirm "test?" "n"; echo $?'
+# Expected output: 1
+
+# Without DOTFILES_CI, should prompt normally (Ctrl+C to exit)
+bash -c 'source bash/bash_logger; confirm "test?" "y"'
+# Expected: shows yellow prompt, waits for input
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bash/bash_logger
+git commit -m "feat: add DOTFILES_CI flag to skip interactive confirm() prompts"
+```
+
+---
+
+### Task 2: Rewrite `test/run-test.sh` and delete `docker-compose.yml`
+
+**Files:**
+- Rewrite: `test/run-test.sh`
+- Delete: `test/docker-compose.yml`
+
+- [ ] **Step 1: Rewrite `test/run-test.sh`**
+
+Replace the entire file with:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+IMAGE_NAME="dotfiles-test"
+
+docker build -f test/Dockerfile -t "$IMAGE_NAME" .
+docker run --rm -e DOTFILES_CI=1 "$IMAGE_NAME" bash -c '
+    set -euo pipefail
+    cd ~/dotfiles
+    chmod +x install.sh tools/*.sh
+    ./install.sh
+
+    echo "--- Smoke tests ---"
+    source ~/.bash_paths
+    for f in ~/.tool_configs/*.sh; do source "$f"; done
+
+    # Symlinks
+    test -L ~/.bashrc
+    test -L ~/.bash_aliases
+    test -L ~/.tmux.conf
+
+    # Dev tools
+    command -v java
+    command -v python3
+    command -v node
+    command -v bun
+    command -v go
+    command -v rustc
+    command -v nvim
+
+    echo "All smoke tests passed"
+'
+docker rmi "$IMAGE_NAME"
+```
+
+Key differences from old script:
+- Uses `docker build` + `docker run` instead of `docker compose`
+- Sets `DOTFILES_CI=1` via `-e` flag
+- Sources `~/.bash_paths` and `~/.tool_configs/*.sh` directly (not `~/.bashrc`, which has an interactive guard)
+- Includes inline smoke tests for symlinks and dev tools
+- Cleans up the image at the end
+
+- [ ] **Step 2: Delete `test/docker-compose.yml`**
+
+```bash
+rm test/docker-compose.yml
+```
+
+- [ ] **Step 3: Verify `test/run-test.sh` is executable**
+
+```bash
+chmod +x test/run-test.sh
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/run-test.sh
+git rm test/docker-compose.yml
+git commit -m "refactor: simplify test to plain docker, add smoke tests, drop compose"
+```
+
+---
+
+### Task 3: Add GitHub Actions workflow
+
+**Files:**
+- Create: `.github/workflows/test.yml`
+
+- [ ] **Step 1: Create the workflow file**
+
+```bash
+mkdir -p .github/workflows
+```
+
+Write `.github/workflows/test.yml`:
+
+```yaml
+name: Test Install
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run install test
+        run: ./test/run-test.sh
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/test.yml
+git commit -m "ci: add GitHub Actions workflow for install test"
+```
+
+---
+
+### Task 4: End-to-end local verification
+
+- [ ] **Step 1: Run the full test locally**
+
+```bash
+./test/run-test.sh
+```
+
+Expected: Docker builds the container, install.sh runs non-interactively (all confirms auto-accept), smoke tests verify symlinks exist and all dev tools are on PATH. Ends with "All smoke tests passed".
+
+If any `command -v` check fails, it means that tool's install script failed silently or its PATH setup isn't sourced correctly by `~/.bash_paths` or `~/.tool_configs/*.sh`. Debug by running the container interactively:
+
+```bash
+docker run --rm -it -e DOTFILES_CI=1 dotfiles-test bash
+```
+
+- [ ] **Step 2: Fix any issues found and re-run**
+
+**Known risk:** Docker installation inside the container (`curl -fsSL https://get.docker.com | sh`) may fail because the container has no systemd. Since `install.sh` runs under `set -euo pipefail`, this would abort the entire install. If this happens, the fix is to guard the Docker install section with `[[ "${DOTFILES_CI:-}" != "1" ]]` or change its confirm default to `"n"`.
+
+For any other issues (tool download timeouts, PATH not set correctly), fix the relevant file and re-run `./test/run-test.sh`.
+
+- [ ] **Step 3: Final commit if any fixes were needed**
+
+Stage only the specific files that were changed and commit.

--- a/docs/superpowers/specs/2026-03-21-ci-install-test-design.md
+++ b/docs/superpowers/specs/2026-03-21-ci-install-test-design.md
@@ -40,14 +40,17 @@ Replace the current `docker compose` approach with plain `docker build` + `docke
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-docker build -f test/Dockerfile -t dotfiles-test .
-docker run --rm -e DOTFILES_CI=1 dotfiles-test bash -c '
+IMAGE_NAME="dotfiles-test"
+
+docker build -f test/Dockerfile -t "$IMAGE_NAME" .
+docker run --rm -e DOTFILES_CI=1 "$IMAGE_NAME" bash -c '
     cd ~/dotfiles
     chmod +x install.sh tools/*.sh
     ./install.sh
 
     echo "--- Smoke tests ---"
-    source ~/.bashrc
+    source ~/.bash_paths
+    for f in ~/.tool_configs/*.sh; do source "$f"; done
 
     # Symlinks
     test -L ~/.bashrc
@@ -65,13 +68,20 @@ docker run --rm -e DOTFILES_CI=1 dotfiles-test bash -c '
 
     echo "All smoke tests passed"
 '
+docker rmi "$IMAGE_NAME"
 ```
+
+Note: smoke tests source `~/.bash_paths` and `~/.tool_configs/*.sh` directly instead of `~/.bashrc`, because bashrc has an interactive-shell guard (`case $- in *i*) ...`) that causes it to return early in non-interactive `bash -c` shells.
 
 ### 3. `test/docker-compose.yml` — deleted
 
 No longer needed. The compose file only served `run-test.sh`, which now uses plain Docker commands. Removes the Docker Compose dependency from the test workflow.
 
-### 4. `.github/workflows/test.yml` — new file
+### 4. `test/Dockerfile` — unchanged
+
+The existing Dockerfile (Ubuntu 22.04, testuser with sudo, copies dotfiles in) works as-is. No modifications needed.
+
+### 5. `.github/workflows/test.yml` — new file
 
 ```yaml
 name: Test Install

--- a/docs/superpowers/specs/2026-03-21-ci-install-test-design.md
+++ b/docs/superpowers/specs/2026-03-21-ci-install-test-design.md
@@ -1,0 +1,100 @@
+# CI Install Test Design
+
+## Problem
+
+`install.sh` is interactive — the `confirm()` function in `bash/bash_logger` reads from `/dev/tty`, which fails in CI and non-interactive Docker contexts. This blocks automated testing of the full install flow.
+
+## Solution
+
+An opt-in `DOTFILES_CI=1` environment variable that makes `confirm()` auto-accept defaults instead of reading `/dev/tty`. Combined with a GitHub Actions workflow that builds a Docker container and runs the full install + smoke tests.
+
+## Changes
+
+### 1. `bash/bash_logger` — non-interactive flag (1 line added)
+
+Add an early return to `confirm()` that checks `DOTFILES_CI`:
+
+```bash
+confirm() {
+    local prompt="${1:-Continue?}" default="${2:-y}"
+    [[ "${DOTFILES_CI:-}" == "1" ]] && return $([[ "$default" == "y" ]] && echo 0 || echo 1)
+    local hint=$([[ "$default" == "y" ]] && echo "Y/n" || echo "y/N")
+
+    echo -en "${_C_YELLOW}${_S_LINE} ${_S_WARN}  ${prompt} [${hint}] ${_C_RESET}"
+    read -r response < /dev/tty
+    [[ -z "$response" ]] && response="$default"
+    [[ "$response" =~ ^[Yy]$ ]]
+}
+```
+
+When `DOTFILES_CI=1`: returns 0 (success) if default is "y", returns 1 (failure) if default is "n". No TTY read, no prompt output. Works for all callers — `install.sh` and all `tools/setup_*.sh` scripts — since they all source `bash_logger` via `common.sh`.
+
+All existing `confirm()` calls default to "y" (either explicitly or via the function's own default), so CI mode installs everything: symlinks, essential packages, Docker, all dev tools.
+
+### 2. `test/run-test.sh` — rewritten
+
+Replace the current `docker compose` approach with plain `docker build` + `docker run`. Sets `DOTFILES_CI=1` and includes inline smoke tests.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+docker build -f test/Dockerfile -t dotfiles-test .
+docker run --rm -e DOTFILES_CI=1 dotfiles-test bash -c '
+    cd ~/dotfiles
+    chmod +x install.sh tools/*.sh
+    ./install.sh
+
+    echo "--- Smoke tests ---"
+    source ~/.bashrc
+
+    # Symlinks
+    test -L ~/.bashrc
+    test -L ~/.bash_aliases
+    test -L ~/.tmux.conf
+
+    # Dev tools
+    command -v java
+    command -v python3
+    command -v node
+    command -v bun
+    command -v go
+    command -v rustc
+    command -v nvim
+
+    echo "All smoke tests passed"
+'
+```
+
+### 3. `test/docker-compose.yml` — deleted
+
+No longer needed. The compose file only served `run-test.sh`, which now uses plain Docker commands. Removes the Docker Compose dependency from the test workflow.
+
+### 4. `.github/workflows/test.yml` — new file
+
+```yaml
+name: Test Install
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run install test
+        run: ./test/run-test.sh
+```
+
+CI just calls the same script used for local testing. One job, no matrix.
+
+## Scope Notes
+
+- The `DOTFILES_CI` flag is opt-in — normal interactive usage is unchanged.
+- Docker installation inside the test container (via `get.docker.com`) should work — it installs packages without needing to start the daemon. If it fails in practice, we fix it then.
+- SSH key generation in `setup_git.sh` auto-accepts in CI — creates a throwaway key in the disposable container.
+- Smoke tests are simple shell assertions (`test -L`, `command -v`). No test framework.

--- a/docs/superpowers/specs/2026-03-21-ci-install-test-design.md
+++ b/docs/superpowers/specs/2026-03-21-ci-install-test-design.md
@@ -44,6 +44,7 @@ IMAGE_NAME="dotfiles-test"
 
 docker build -f test/Dockerfile -t "$IMAGE_NAME" .
 docker run --rm -e DOTFILES_CI=1 "$IMAGE_NAME" bash -c '
+    set -euo pipefail
     cd ~/dotfiles
     chmod +x install.sh tools/*.sh
     ./install.sh

--- a/install.sh
+++ b/install.sh
@@ -122,27 +122,29 @@ if command -v apt-get &> /dev/null; then
             log_success "Default essential packages installed"
         fi
         
-        # Install Docker if not already installed
-        if ! command -v docker &> /dev/null; then
-            if confirm "Do you want to install Docker?"; then
-                log_step 2 "Installing Docker..."
-                curl -fsSL https://get.docker.com | sh
-                sudo usermod -aG docker "$USER"
-                log_warn "You may need to log out and back in for Docker permissions to take effect"
+        # Install Docker if not already installed (skip in CI — no systemd in containers)
+        if [[ "${DOTFILES_CI:-}" != "1" ]]; then
+            if ! command -v docker &> /dev/null; then
+                if confirm "Do you want to install Docker?"; then
+                    log_step 2 "Installing Docker..."
+                    curl -fsSL https://get.docker.com | sh
+                    sudo usermod -aG docker "$USER"
+                    log_warn "You may need to log out and back in for Docker permissions to take effect"
+                fi
             fi
-        fi
-        
-        # Docker Compose - modern Docker ships with 'docker compose' as a plugin
-        if docker compose version &> /dev/null; then
-            log_success "Docker Compose plugin already available: $(docker compose version --short)"
-        elif ! command -v docker-compose &> /dev/null; then
-            if confirm "Do you want to install the Docker Compose plugin?"; then
-                log_step 3 "Installing Docker Compose plugin..."
-                sudo apt-get install -y docker-compose-plugin
-                log_success "Docker Compose plugin installed"
+
+            # Docker Compose - modern Docker ships with 'docker compose' as a plugin
+            if docker compose version &> /dev/null; then
+                log_success "Docker Compose plugin already available: $(docker compose version --short)"
+            elif ! command -v docker-compose &> /dev/null; then
+                if confirm "Do you want to install the Docker Compose plugin?"; then
+                    log_step 3 "Installing Docker Compose plugin..."
+                    sudo apt-get install -y docker-compose-plugin
+                    log_success "Docker Compose plugin installed"
+                fi
+            else
+                log_info "Legacy docker-compose found: $(docker-compose --version)"
             fi
-        else
-            log_info "Legacy docker-compose found: $(docker-compose --version)"
         fi
     fi
 fi

--- a/tools/setup_golang.sh
+++ b/tools/setup_golang.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
-# Install Go (Golang)
+# Install Go and golangci-lint with pinned versions
+# To upgrade: bump the version variables below and re-run.
 
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$DOTFILES_DIR/tools/common.sh"
+
+# --- Pinned versions (bump these to upgrade) ---
+GO_VERSION="1.26.1"
+GOLANGCI_LINT_VERSION="2.11.3"
 
 INSTALL_DIR="/usr/local"
 
@@ -27,43 +32,67 @@ case "$(uname -s)" in
 esac
 log_detail "Detected: ${OS}/${ARCH}"
 
-# --- Fetch latest stable version ---
-log_step 2 "Checking for latest Go version..."
-GO_VERSION=$(curl -sL 'https://go.dev/VERSION?m=text' | head -1 | sed 's/^go//')
-if [ -z "$GO_VERSION" ]; then
-    die "Could not determine latest Go version. Check your internet connection."
-fi
-log_detail "Latest stable: ${GO_VERSION}"
+# --- Install Go ---
+log_step 2 "Checking Go installation..."
+log_detail "Pinned version: ${GO_VERSION}"
 
-# --- Check existing installation ---
+NEED_GO_INSTALL=true
 if [ -d "${INSTALL_DIR}/go" ] && [ -x "${INSTALL_DIR}/go/bin/go" ]; then
     CURRENT_VERSION=$(${INSTALL_DIR}/go/bin/go version | awk '{print $3}' | sed 's/go//')
     if [ "${CURRENT_VERSION}" == "${GO_VERSION}" ]; then
         log_info "Go ${GO_VERSION} is already installed."
-        exit 0
+        NEED_GO_INSTALL=false
     else
         log_warn "Found Go ${CURRENT_VERSION}. Upgrading to ${GO_VERSION}..."
         sudo rm -rf "${INSTALL_DIR}/go"
     fi
 fi
 
-# --- Download to temp directory ---
-GO_ARCHIVE="go${GO_VERSION}.${OS}-${ARCH}.tar.gz"
-DOWNLOAD_URL="https://go.dev/dl/${GO_ARCHIVE}"
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
+if [ "$NEED_GO_INSTALL" = true ]; then
+    GO_ARCHIVE="go${GO_VERSION}.${OS}-${ARCH}.tar.gz"
+    DOWNLOAD_URL="https://go.dev/dl/${GO_ARCHIVE}"
+    TMPDIR=$(mktemp -d)
+    trap 'rm -rf "$TMPDIR"' EXIT
 
-log_step 3 "Installing Go ${GO_VERSION}..."
+    log_step 3 "Installing Go ${GO_VERSION}..."
 
-log_detail "Downloading ${GO_ARCHIVE}..."
-curl -fsSL "${DOWNLOAD_URL}" -o "${TMPDIR}/${GO_ARCHIVE}"
+    log_detail "Downloading ${GO_ARCHIVE}..."
+    curl -fsSL "${DOWNLOAD_URL}" -o "${TMPDIR}/${GO_ARCHIVE}"
 
-log_detail "Extracting to ${INSTALL_DIR}..."
-sudo tar -C "${INSTALL_DIR}" -xzf "${TMPDIR}/${GO_ARCHIVE}"
+    log_detail "Extracting to ${INSTALL_DIR}..."
+    sudo tar -C "${INSTALL_DIR}" -xzf "${TMPDIR}/${GO_ARCHIVE}"
 
-if [ ! -d "${INSTALL_DIR}/go" ]; then
-    die "Failed to extract Go. Check permissions and available space."
+    if [ ! -d "${INSTALL_DIR}/go" ]; then
+        die "Failed to extract Go. Check permissions and available space."
+    fi
+
+    log_success "Go ${GO_VERSION} (${OS}/${ARCH}) installed."
 fi
 
-log_success "Go ${GO_VERSION} (${OS}/${ARCH}) installed."
+# --- Install golangci-lint ---
+log_section "golangci-lint Setup"
+log_detail "Pinned version: ${GOLANGCI_LINT_VERSION}"
+
+# Ensure GOPATH/bin exists for the install target
+export GOPATH="${GOPATH:-$HOME/go}"
+export PATH="${INSTALL_DIR}/go/bin:${GOPATH}/bin:${PATH}"
+
+NEED_LINT_INSTALL=true
+if command -v golangci-lint &> /dev/null; then
+    CURRENT_LINT_VERSION=$(golangci-lint --version 2>/dev/null | grep -oP '\d+\.\d+\.\d+' | head -1)
+    if [ "${CURRENT_LINT_VERSION}" == "${GOLANGCI_LINT_VERSION}" ]; then
+        log_info "golangci-lint ${GOLANGCI_LINT_VERSION} is already installed."
+        NEED_LINT_INSTALL=false
+    else
+        log_warn "Found golangci-lint ${CURRENT_LINT_VERSION}. Upgrading to ${GOLANGCI_LINT_VERSION}..."
+    fi
+fi
+
+if [ "$NEED_LINT_INSTALL" = true ]; then
+    log_step 4 "Installing golangci-lint ${GOLANGCI_LINT_VERSION}..."
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | \
+        sh -s -- -b "${GOPATH}/bin" "v${GOLANGCI_LINT_VERSION}"
+    log_success "golangci-lint ${GOLANGCI_LINT_VERSION} installed to ${GOPATH}/bin"
+fi
+
 log_info "PATH is managed by ~/.tool_configs/golang.sh"


### PR DESCRIPTION
## Summary
- Pin Go version to 1.26.1 and golangci-lint to 2.11.3 in `setup_golang.sh` instead of fetching latest dynamically
- Add golangci-lint installation via official install script to `$GOPATH/bin`
- Idempotent: skips install if correct version is already present, upgrades if version differs

## Test plan
- [ ] Run `./tools/setup_golang.sh` on a clean machine — verify Go 1.26.1 and golangci-lint 2.11.3 are installed
- [ ] Run it again — verify it skips both installs ("already installed")
- [ ] Verify `go version` and `golangci-lint --version` output correct versions
- [ ] Verify `golangci-lint run` works in a Go project