### PR TITLE
Add GitHub Actions CI for install test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test-install:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Run install test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Test Install
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run install test
+        run: ./test/run-test.sh

--- a/bash/bash_logger
+++ b/bash/bash_logger
@@ -133,7 +133,7 @@ log_error() {
 
 log_step() {
     local num text
-    if [[ -z "$2" ]]; then
+    if [[ -z "${2:-}" ]]; then
         # Single argument: treat as text, no number
         text="$1"
         echo -e "${_C_BOLD_YELLOW}${_S_LINE}${_C_RESET}"

--- a/bash/bash_logger
+++ b/bash/bash_logger
@@ -183,6 +183,7 @@ require_cmd() {
 # Prompt for yes/no confirmation (reads from /dev/tty to work when stdin is piped)
 confirm() {
     local prompt="${1:-Continue?}" default="${2:-y}"
+    [[ "${DOTFILES_CI:-}" == "1" ]] && return $([[ "$default" == "y" ]] && echo 0 || echo 1)
     local hint=$([[ "$default" == "y" ]] && echo "Y/n" || echo "y/N")
 
     echo -en "${_C_YELLOW}${_S_LINE} ${_S_WARN}  ${prompt} [${hint}] ${_C_RESET}"

--- a/bash/tool_configs/golang.sh
+++ b/bash/tool_configs/golang.sh
@@ -8,7 +8,7 @@ if [ -d "/usr/local/go/bin" ]; then
 fi
 
 # Set GOPATH to the default location if it's not already set
-if [ -z "$GOPATH" ]; then
+if [ -z "${GOPATH:-}" ]; then
     export GOPATH="$HOME/go"
 fi
 

--- a/config/vscode/extensions.txt
+++ b/config/vscode/extensions.txt
@@ -17,6 +17,7 @@ ms-python.python
 peakchen90.open-html-in-browser
 redhat.java
 rogalmic.bash-debug
+timonwong.shellcheck
 visualstudioexptteam.intellicode-api-usage-examples
 visualstudioexptteam.vscodeintellicode
 vscjava.vscode-gradle

--- a/install.sh
+++ b/install.sh
@@ -122,27 +122,29 @@ if command -v apt-get &> /dev/null; then
             log_success "Default essential packages installed"
         fi
         
-        # Install Docker if not already installed
-        if ! command -v docker &> /dev/null; then
-            if confirm "Do you want to install Docker?"; then
-                log_step 2 "Installing Docker..."
-                curl -fsSL https://get.docker.com | sh
-                sudo usermod -aG docker "$USER"
-                log_warn "You may need to log out and back in for Docker permissions to take effect"
+        # Install Docker if not already installed (skip in CI — no systemd in containers)
+        if [[ "${DOTFILES_CI:-}" != "1" ]]; then
+            if ! command -v docker &> /dev/null; then
+                if confirm "Do you want to install Docker?"; then
+                    log_step 2 "Installing Docker..."
+                    curl -fsSL https://get.docker.com | sh
+                    sudo usermod -aG docker "$USER"
+                    log_warn "You may need to log out and back in for Docker permissions to take effect"
+                fi
             fi
-        fi
-        
-        # Docker Compose - modern Docker ships with 'docker compose' as a plugin
-        if docker compose version &> /dev/null; then
-            log_success "Docker Compose plugin already available: $(docker compose version --short)"
-        elif ! command -v docker-compose &> /dev/null; then
-            if confirm "Do you want to install the Docker Compose plugin?"; then
-                log_step 3 "Installing Docker Compose plugin..."
-                sudo apt-get install -y docker-compose-plugin
-                log_success "Docker Compose plugin installed"
+
+            # Docker Compose - modern Docker ships with 'docker compose' as a plugin
+            if docker compose version &> /dev/null; then
+                log_success "Docker Compose plugin already available: $(docker compose version --short)"
+            elif ! command -v docker-compose &> /dev/null; then
+                if confirm "Do you want to install the Docker Compose plugin?"; then
+                    log_step 3 "Installing Docker Compose plugin..."
+                    sudo apt-get install -y docker-compose-plugin
+                    log_success "Docker Compose plugin installed"
+                fi
+            else
+                log_info "Legacy docker-compose found: $(docker-compose --version)"
             fi
-        else
-            log_info "Legacy docker-compose found: $(docker-compose --version)"
         fi
     fi
 fi

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,9 +1,0 @@
-version: '3.9'
-
-services:
-  dotfiles-test:
-    build:
-      context: ..
-      dockerfile: test/Dockerfile
-    tty: true
-    stdin_open: true

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,19 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
+cd "$(dirname "$0")/.."
 
-# Go to the directory where the docker-compose.yml is located
-cd "$(dirname "$0")"
+IMAGE_NAME="dotfiles-test"
 
-# Build and start the container
-docker compose up -d --build
-
-# Connect to the container and make scripts executable and cd into dotfiles directory
-docker compose exec dotfiles-test bash -c '
+docker build -f test/Dockerfile -t "$IMAGE_NAME" .
+docker run --rm -e DOTFILES_CI=1 "$IMAGE_NAME" bash -c '
+    set -euo pipefail
     cd ~/dotfiles
-    chmod +x install.sh
-    chmod +x tools/*.sh
+    chmod +x install.sh tools/*.sh
     ./install.sh
-'
 
-# When exiting the container, stop it, remove containers, networks, ALL images, orphans, AND named volumes
-docker compose down --rmi all --volumes --remove-orphans
+    echo "--- Smoke tests ---"
+    source ~/.bash_paths
+    for f in ~/.tool_configs/*.sh; do source "$f"; done
+
+    # Symlinks
+    test -L ~/.bashrc
+    test -L ~/.bash_aliases
+    test -L ~/.tmux.conf
+
+    # Dev tools
+    command -v java
+    command -v python3
+    command -v node
+    command -v bun
+    command -v go
+    command -v rustc
+    command -v nvim
+
+    echo "All smoke tests passed"
+'
+docker rmi "$IMAGE_NAME"

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -41,13 +41,14 @@ docker run --rm -e DOTFILES_CI=1 "${IMAGE_NAME}:installed" bash -c '
     }
 
     # Source tool configs the same way bashrc does (without interactive guard)
-    # Disable set -u: third-party scripts (SDKMAN, nvm) use unbound variables
-    set +u
+    # Disable strict mode: third-party scripts (SDKMAN, nvm) use unbound
+    # variables and have commands that return non-zero during init
+    set +eu
     source ~/.bash_paths 2>/dev/null || true
     for f in ~/.tool_configs/*.sh; do
         [ -f "$f" ] && source "$f"
     done
-    set -u
+    set -eu
 
     echo "--- Symlinks ---"
     check "~/.bashrc is a symlink"       test -L ~/.bashrc

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -41,10 +41,13 @@ docker run --rm -e DOTFILES_CI=1 "${IMAGE_NAME}:installed" bash -c '
     }
 
     # Source tool configs the same way bashrc does (without interactive guard)
+    # Disable set -u: third-party scripts (SDKMAN, nvm) use unbound variables
+    set +u
     source ~/.bash_paths 2>/dev/null || true
     for f in ~/.tool_configs/*.sh; do
         [ -f "$f" ] && source "$f"
     done
+    set -u
 
     echo "--- Symlinks ---"
     check "~/.bashrc is a symlink"       test -L ~/.bashrc

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 IMAGE_NAME="dotfiles-test"
+trap 'docker rmi "$IMAGE_NAME" 2>/dev/null || true' EXIT
 
 docker build -f test/Dockerfile -t "$IMAGE_NAME" .
 docker run --rm -e DOTFILES_CI=1 "$IMAGE_NAME" bash -c '
@@ -13,7 +14,7 @@ docker run --rm -e DOTFILES_CI=1 "$IMAGE_NAME" bash -c '
 
     echo "--- Smoke tests ---"
     source ~/.bash_paths
-    for f in ~/.tool_configs/*.sh; do source "$f"; done
+    for f in ~/.tool_configs/*.sh; do [[ -f "$f" ]] && source "$f"; done
 
     # Symlinks
     test -L ~/.bashrc
@@ -31,4 +32,3 @@ docker run --rm -e DOTFILES_CI=1 "$IMAGE_NAME" bash -c '
 
     echo "All smoke tests passed"
 '
-docker rmi "$IMAGE_NAME"

--- a/tools/setup_git.sh
+++ b/tools/setup_git.sh
@@ -17,32 +17,38 @@ fi
 log_step 1 "Setting up Git configuration..."
 
 # --- Get user information ---
-log_info "Please provide your Git configuration details:"
-
-# Get name
-current_name=$(git config --global user.name 2>/dev/null || echo "")
-if [ -n "$current_name" ]; then
-    read -p "Git user name (current: $current_name): " git_name
-    git_name=${git_name:-$current_name}
+if [[ "${DOTFILES_CI:-}" == "1" ]]; then
+    git_name="CI Test User"
+    git_email="ci@test.local"
+    log_info "CI mode: using dummy Git identity"
 else
-    read -p "Git user name: " git_name
-    while [ -z "$git_name" ]; do
-        log_warn "Name cannot be empty."
+    log_info "Please provide your Git configuration details:"
+
+    # Get name
+    current_name=$(git config --global user.name 2>/dev/null || echo "")
+    if [ -n "$current_name" ]; then
+        read -p "Git user name (current: $current_name): " git_name
+        git_name=${git_name:-$current_name}
+    else
         read -p "Git user name: " git_name
-    done
-fi
+        while [ -z "$git_name" ]; do
+            log_warn "Name cannot be empty."
+            read -p "Git user name: " git_name
+        done
+    fi
 
-# Get email
-current_email=$(git config --global user.email 2>/dev/null || echo "")
-if [ -n "$current_email" ]; then
-    read -p "Git user email (current: $current_email): " git_email
-    git_email=${git_email:-$current_email}
-else
-    read -p "Git user email: " git_email
-    while [ -z "$git_email" ]; do
-        log_warn "Email cannot be empty."
+    # Get email
+    current_email=$(git config --global user.email 2>/dev/null || echo "")
+    if [ -n "$current_email" ]; then
+        read -p "Git user email (current: $current_email): " git_email
+        git_email=${git_email:-$current_email}
+    else
         read -p "Git user email: " git_email
-    done
+        while [ -z "$git_email" ]; do
+            log_warn "Email cannot be empty."
+            read -p "Git user email: " git_email
+        done
+    fi
 fi
 
 # --- Set git configuration ---
@@ -94,8 +100,10 @@ if [ ! -f "$ssh_key" ]; then
         log_kv "GitLab" "https://gitlab.com/-/profile/keys"
         log_kv "Bitbucket" "https://bitbucket.org/account/settings/ssh-keys/"
         
-        echo
-        read -p "Press Enter after you've added the key to your Git hosting service..."
+        if [[ "${DOTFILES_CI:-}" != "1" ]]; then
+            echo
+            read -p "Press Enter after you've added the key to your Git hosting service..."
+        fi
         
         # Test SSH connection to common Git hosts
         log_step 3 "Testing SSH connections..."

--- a/tools/setup_java.sh
+++ b/tools/setup_java.sh
@@ -41,16 +41,15 @@ else
 fi
 
 # Source SDKMAN to ensure its commands are available
+# SDKMAN uses unset variables internally, so disable strict unset checking
 set +u
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 # Auto-answer prompts in CI to avoid hanging on interactive questions
 [[ "${DOTFILES_CI:-}" == "1" ]] && sdkman_auto_answer=true
-set -u
 
 log_section "Java & Maven"
 
 # Install specified Java version if not already present
-# Using 'sdk home' to check if version exists is more reliable than parsing 'sdk list'
 if ! sdk home java "$JAVA_VERSION" >/dev/null 2>&1; then
     log_step 3 "Installing Java version $JAVA_VERSION..."
     sdk install java "$JAVA_VERSION"
@@ -63,7 +62,6 @@ fi
 sdk default java "$JAVA_VERSION" >/dev/null 2>&1 || true
 
 # Install latest Maven if not already present
-# Check if mvn is in path (after sdkman init)
 if ! command -v mvn >/dev/null; then
     log_step 4 "Installing latest stable Maven..."
     sdk install maven "$MAVEN_VERSION"
@@ -76,3 +74,4 @@ log_section "Setup Complete"
 log_info "Current active versions:"
 log_kv "Java"  "$(sdk current java)"
 log_kv "Maven" "$(sdk current maven)"
+set -u

--- a/tools/setup_java.sh
+++ b/tools/setup_java.sh
@@ -8,7 +8,7 @@ DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$DOTFILES_DIR/tools/common.sh"
 
 # --- Configuration ---
-JAVA_VERSION="21.0.3-tem" # Specify a recent Long-Term Support (LTS) version
+JAVA_VERSION="21.0.10-tem" # Specify a recent Long-Term Support (LTS) version
 MAVEN_VERSION=""          # Let SDKMAN install the latest stable version
 
 log_header "Java Environment Setup"
@@ -43,6 +43,8 @@ fi
 # Source SDKMAN to ensure its commands are available
 set +u
 source "$HOME/.sdkman/bin/sdkman-init.sh"
+# Auto-answer prompts in CI to avoid hanging on interactive questions
+[[ "${DOTFILES_CI:-}" == "1" ]] && sdkman_auto_answer=true
 set -u
 
 log_section "Java & Maven"

--- a/tools/setup_node.sh
+++ b/tools/setup_node.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Install Node.js ecosystem: nvm, Node.js, npm, pnpm, TypeScript
 
-set -euo pipefail
+set -eo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -13,8 +13,6 @@ source "$DOTFILES_DIR/tools/common.sh"
 
 load_nvm() {
     export NVM_DIR="$HOME/.nvm"
-    # nvm uses unset variables internally, so disable strict unset checking
-    set +u
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 }
 

--- a/tools/setup_node.sh
+++ b/tools/setup_node.sh
@@ -13,9 +13,9 @@ source "$DOTFILES_DIR/tools/common.sh"
 
 load_nvm() {
     export NVM_DIR="$HOME/.nvm"
+    # nvm uses unset variables internally, so disable strict unset checking
     set +u
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-    set -u
 }
 
 get_latest_nvm_version() {
@@ -123,3 +123,4 @@ log_info "pnpm: $PNPM_VER"
 log_info "tsc:  $TSC_VER"
 
 log_info "Run 'source ~/.bashrc' or start a new terminal to use nvm"
+set -u

--- a/tools/setup_python.sh
+++ b/tools/setup_python.sh
@@ -40,8 +40,8 @@ log_section "Python Environment"
 
 # Install a default Python version
 log_step 2 "Installing Python 3.12..."
-uv python install 3.12
-log_success "Python 3.12 installed"
+uv python install 3.12 --default
+log_success "Python 3.12 installed (python3 available on PATH)"
 
 # Set Python 3.12 as the default
 log_step 3 "Pinning Python 3.12 as global default..."


### PR DESCRIPTION
## Summary

- Add `DOTFILES_CI=1` env var flag that makes `confirm()` in `bash_logger` auto-accept defaults, enabling non-interactive installs
- Rewrite `test/run-test.sh` to use plain `docker build`/`docker run` with inline smoke tests (symlinks + dev tool verification)
- Delete `test/docker-compose.yml` — no longer needed
- Add `.github/workflows/test.yml` that runs the install test on PRs and pushes to main
- Skip Docker/Docker Compose installation in CI (no systemd in containers)

## Test plan

- [x] CI workflow runs successfully on this PR
- [x] Smoke tests verify symlinks exist (`~/.bashrc`, `~/.bash_aliases`, `~/.tmux.conf`)
- [x] Smoke tests verify dev tools are on PATH (`java`, `python3`, `node`, `bun`, `go`, `rustc`, `nvim`)
- [x] Interactive `confirm()` still works normally without `DOTFILES_CI=1`