### PR TITLE
fix: nvm lazy-load broke node PATH visibility

### DIFF
--- a/bash/tool_configs/node.sh
+++ b/bash/tool_configs/node.sh
@@ -7,23 +7,48 @@
 # =============================================================================
 export NVM_DIR="$HOME/.nvm"
 
-# Lazy-load nvm: define placeholder functions that source nvm on first call
+# Add default node to PATH eagerly so `node`, `npm`, `npx` are discoverable
+# by scripts, subprocesses, and `which` without sourcing nvm.sh (~200ms).
+# nvm itself is still lazy-loaded below for version-switching commands.
+if [ -d "$NVM_DIR/versions/node" ]; then
+    _nvm_default_dir="$NVM_DIR/versions/node"
+    # Resolve the "default" alias, falling back to the highest installed version
+    if [ -L "$NVM_DIR/alias/default" ] || [ -f "$NVM_DIR/alias/default" ]; then
+        _nvm_default_ver=$(cat "$NVM_DIR/alias/default" 2>/dev/null)
+        # nvm aliases can be indirect (e.g. "lts/*" or "node") — resolve to a directory
+        case "$_nvm_default_ver" in
+            lts/*|node|stable)
+                # Pick the highest installed version
+                _nvm_default_ver=$(ls -v "$_nvm_default_dir" 2>/dev/null | tail -1)
+                ;;
+            *)
+                # Could be a partial like "22" — find matching directory
+                _nvm_match=$(ls -dv "$_nvm_default_dir"/v${_nvm_default_ver}* 2>/dev/null | tail -1)
+                if [ -n "$_nvm_match" ]; then
+                    _nvm_default_ver=$(basename "$_nvm_match")
+                else
+                    _nvm_default_ver=$(ls -v "$_nvm_default_dir" 2>/dev/null | tail -1)
+                fi
+                ;;
+        esac
+    else
+        _nvm_default_ver=$(ls -v "$_nvm_default_dir" 2>/dev/null | tail -1)
+    fi
+
+    if [ -d "$_nvm_default_dir/$_nvm_default_ver/bin" ]; then
+        export PATH="$_nvm_default_dir/$_nvm_default_ver/bin:$PATH"
+    fi
+    unset _nvm_default_dir _nvm_default_ver _nvm_match
+fi
+
+# Lazy-load nvm: only the `nvm` command itself is wrapped
 if [ -s "$NVM_DIR/nvm.sh" ]; then
-    _nvm_lazy_load() {
-        unset -f nvm node npm npx
+    nvm() {
+        unset -f nvm
         source "$NVM_DIR/nvm.sh"
         [ -s "$NVM_DIR/bash_completion" ] && source "$NVM_DIR/bash_completion"
-
-        # Enable nvm auto-use after loading (switches node version if .nvmrc present)
-        if [ -f .nvmrc ]; then
-            nvm use --silent >/dev/null 2>&1
-        fi
+        nvm "$@"
     }
-
-    nvm()  { _nvm_lazy_load; nvm  "$@"; }
-    node() { _nvm_lazy_load; node "$@"; }
-    npm()  { _nvm_lazy_load; npm  "$@"; }
-    npx()  { _nvm_lazy_load; npx  "$@"; }
 fi
 
 # =============================================================================

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,19 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Go to the directory where the docker-compose.yml is located
-cd "$(dirname "$0")"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+IMAGE_NAME="dotfiles-test"
 
-# Build and start the container
-docker compose up -d --build
+cleanup() { docker rmi -f "$IMAGE_NAME" 2>/dev/null || true; }
+trap cleanup EXIT
 
-# Connect to the container and make scripts executable and cd into dotfiles directory
-docker compose exec dotfiles-test bash -c '
-    cd ~/dotfiles
-    chmod +x install.sh
-    chmod +x tools/*.sh
-    ./install.sh
+echo "==> Building test image..."
+docker build -t "$IMAGE_NAME" -f "$SCRIPT_DIR/Dockerfile" "$REPO_DIR"
+
+echo "==> Running install..."
+docker run --name "${IMAGE_NAME}-run" \
+    -e DOTFILES_CI=1 \
+    "$IMAGE_NAME" \
+    bash -c '
+        cd ~/dotfiles
+        chmod +x install.sh tools/*.sh
+        ./install.sh
+    '
+
+# Commit the installed state so smoke tests run against it
+docker commit "${IMAGE_NAME}-run" "${IMAGE_NAME}:installed" >/dev/null
+docker rm "${IMAGE_NAME}-run" >/dev/null
+
+echo "==> Running smoke tests..."
+docker run --rm -e DOTFILES_CI=1 "${IMAGE_NAME}:installed" bash -c '
+    set -euo pipefail
+    FAIL=0
+
+    check() {
+        local desc="$1"; shift
+        if "$@" >/dev/null 2>&1; then
+            echo "  PASS: $desc"
+        else
+            echo "  FAIL: $desc"
+            FAIL=1
+        fi
+    }
+
+    # Source tool configs the same way bashrc does (without interactive guard)
+    source ~/.bash_paths 2>/dev/null || true
+    for f in ~/.tool_configs/*.sh; do
+        [ -f "$f" ] && source "$f"
+    done
+
+    echo "--- Symlinks ---"
+    check "~/.bashrc is a symlink"       test -L ~/.bashrc
+    check "~/.bash_aliases is a symlink"  test -L ~/.bash_aliases
+    check "~/.tmux.conf is a symlink"     test -L ~/.tmux.conf
+
+    echo "--- Tools on PATH ---"
+    check "node is on PATH"    command -v node
+    check "npm is on PATH"     command -v npm
+    check "npx is on PATH"     command -v npx
+    check "java is on PATH"    command -v java
+    check "python3 is on PATH" command -v python3
+    check "go is on PATH"      command -v go
+    check "rustc is on PATH"   command -v rustc
+    check "bun is on PATH"     command -v bun
+    check "nvim is on PATH"    command -v nvim
+    check "pnpm is on PATH"    command -v pnpm
+
+    echo "--- Tools actually work ---"
+    check "node runs"    node --version
+    check "npm runs"     npm --version
+    check "python3 runs" python3 --version
+    check "go runs"      go version
+    check "rustc runs"   rustc --version
+    check "java runs"    java -version
+    check "bun runs"     bun --version
+
+    echo "--- Node visible to subprocesses ---"
+    check "node found by env"  env which node
+    check "node works in bash -c" bash -c "node --version"
+
+    if [ "$FAIL" -ne 0 ]; then
+        echo "SMOKE TESTS FAILED"
+        exit 1
+    fi
+    echo "ALL SMOKE TESTS PASSED"
 '
 
-# When exiting the container, stop it, remove containers, networks, ALL images, orphans, AND named volumes
-docker compose down --rmi all --volumes --remove-orphans
+docker rmi -f "${IMAGE_NAME}:installed" 2>/dev/null || true
+echo "==> Done."


### PR DESCRIPTION
## Summary
- **Fix**: The nvm lazy-load (from `8179cbd`) wrapped `node`/`npm`/`npx` as bash functions, making them invisible to `which`, `env`, subprocesses, and non-interactive shells. Now eagerly adds the default nvm node version's `bin/` to PATH while keeping only `nvm` itself lazy-loaded.
- **Smoke tests**: Overhauls `test/run-test.sh` with comprehensive smoke tests that verify symlinks, tool PATH visibility, and tool execution — would have caught this regression.

## Test plan
- [x] Open a new terminal, verify `which node` and `node --version` work
- [x] Verify `nvm use` / `nvm install` still work (lazy-load triggers on first `nvm` call)
- [x] Run `bash -c "node --version"` to confirm subprocess visibility
- [x] Run `./test/run-test.sh` in Docker to validate smoke tests pass