### PR TITLE
fix: use corepack exclusively for pnpm, pin node 24

### DIFF
--- a/bash/tool_configs/node.sh
+++ b/bash/tool_configs/node.sh
@@ -51,11 +51,6 @@ if [ -s "$NVM_DIR/nvm.sh" ]; then
     }
 fi
 
-# =============================================================================
-# pnpm
-# =============================================================================
-export PNPM_HOME="$HOME/.local/share/pnpm"
-case ":$PATH:" in
-  *":$PNPM_HOME:"*) ;;
-  *) [ -d "$PNPM_HOME" ] && export PATH="$PNPM_HOME:$PATH" ;;
-esac
+# pnpm is provided by corepack via the default node installation above.
+# No separate PNPM_HOME or PATH entry needed — the corepack shim lives
+# in the same bin directory as node/npm/npx.

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -75,6 +75,7 @@ docker run --rm -e DOTFILES_CI=1 "${IMAGE_NAME}:installed" bash -c '
     check "rustc runs"   rustc --version
     check "java runs"    java -version
     check "bun runs"     bun --version
+    check "pnpm runs"    pnpm --version
 
     echo "--- Node visible to subprocesses ---"
     check "node found by env"  env which node

--- a/tools/setup_node.sh
+++ b/tools/setup_node.sh
@@ -32,15 +32,14 @@ get_latest_nvm_version() {
 }
 
 ensure_pnpm() {
-    if command -v corepack &> /dev/null; then
-        log_step "Enabling corepack for pnpm..."
-        corepack enable
-        log_detail "Preparing pnpm via corepack..."
-        corepack prepare pnpm@latest --activate
-    else
-        log_info "Corepack not available, installing pnpm via npm..."
-        npm install -g pnpm
+    if ! command -v corepack &> /dev/null; then
+        log_error "corepack not found — it ships with Node 16.9+. Check your node installation."
+        return 1
     fi
+    log_step "Enabling corepack for pnpm..."
+    corepack enable
+    log_detail "Preparing pnpm@latest via corepack..."
+    corepack prepare pnpm@latest --activate
 }
 
 ensure_typescript() {
@@ -72,26 +71,27 @@ load_nvm
 # Node.js Installation
 # =============================================================================
 
-if ! command -v node &> /dev/null; then
-    log_step 2 "Installing Node.js LTS..."
-    nvm install --lts
-    nvm use --lts
+NODE_MAJOR=24
 
-    log_step 3 "Updating npm to latest..."
-    npm install -g npm@latest
+if ! nvm ls "$NODE_MAJOR" &> /dev/null; then
+    log_step 2 "Installing Node.js $NODE_MAJOR..."
+    nvm install "$NODE_MAJOR"
 else
-    log_info "Node.js already installed: $(node --version)"
+    log_info "Node.js $NODE_MAJOR already installed: $(node --version)"
 fi
+
+log_step 3 "Setting Node.js $NODE_MAJOR as default..."
+nvm alias default "$NODE_MAJOR"
+nvm use "$NODE_MAJOR"
+
+log_detail "Updating npm to latest..."
+npm install -g npm@latest
 
 # =============================================================================
 # pnpm Setup (via corepack)
 # =============================================================================
 
-if ! command -v pnpm &> /dev/null; then
-    ensure_pnpm
-else
-    log_info "pnpm already installed: $(pnpm --version)"
-fi
+ensure_pnpm
 
 # =============================================================================
 # TypeScript


### PR DESCRIPTION
## Summary

- **Remove `PNPM_HOME` PATH block from `node.sh`** — a stale standalone pnpm 8.15.3 binary at `~/.local/share/pnpm/pnpm` was shadowing the corepack-managed pnpm 10.x shim in node's bin dir. Since corepack places the pnpm shim alongside node/npm/npx, no separate PATH entry is needed.
- **Remove `npm install -g pnpm` fallback from `setup_node.sh`** — this is how the stale binary got there in the first place. Corepack is required; fail loudly if it's missing.
- **Always run `corepack enable` + `corepack prepare`** — don't skip when pnpm is already found on PATH, since it could be a stale version.
- **Pin node 24 as default** — install node 24 specifically and set it as the nvm default, instead of generic `--lts`.
- **Add `pnpm runs` smoke test** to `run-test.sh`.

## Breaking changes

- Machines with node < 16.9 (no corepack) will fail `setup_node.sh` instead of silently falling back to `npm install -g pnpm`.
- Any standalone pnpm installed at `~/.local/share/pnpm` will no longer be on PATH. Manual cleanup needed: `rm ~/.local/share/pnpm/pnpm`.

## Local env cleanup (post-merge)

```bash
rm ~/.local/share/pnpm/pnpm
source ~/.bashrc
pnpm -v  # should show 10.x
```

## Test plan

- [ ] CI smoke tests pass (pnpm on PATH + pnpm runs)
- [ ] Fresh `./install.sh` on clean machine installs node 24 + pnpm 10 via corepack
- [ ] Existing machine: after removing stale binary and re-sourcing, `pnpm -v` shows 10.x