### PR TITLE
[codex] Add global Codex guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ dotfiles/
 ├── config/                     # Application configurations
 │   ├── nvim/                   # Neovim / LazyVim configuration
 │   ├── codex/
-│   │   └── AGENTS.md           # Global Codex guidance
+│   │   ├── AGENTS.md           # Global Codex guidance
+│   │   └── steering/           # Detailed global Codex steering docs
 │   ├── tmux.conf               # Tmux configuration
 │   └── vscode/                 # VS Code settings
 │       ├── extensions.txt      # Recommended extensions

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ During installation, you'll be prompted to choose between two installation metho
   - Go: Installs Go directly from the official website.
   - Rust: Uses rustup for toolchain management (rustc, cargo, clippy, rustfmt).
   - Neovim: Builds from source with LazyVim configuration. See [top Neovim configs](https://dotfyle.com/neovim/configurations/top) for inspiration.
+- **Codex Guidance**: Global Codex instructions installed to `~/.codex/AGENTS.md` so every local Codex session inherits the same development preferences.
 
 - **Docker Support**: Optional installation of Docker and Docker Compose
 
@@ -146,6 +147,7 @@ ls -la  # Should show a backup file with timestamp
 - Add your own aliases to `.bash_aliases`
 - Add custom functions to `.bash_functions`
 - Modify PATH settings in `.bash_paths`
+- Modify Codex agent guidance in `config/codex/AGENTS.md`
 - Store secrets and API keys in `.bash_secrets`
 
 ## Structure
@@ -172,6 +174,8 @@ dotfiles/
 │       └── rust.sh             # Rust/Cargo configuration
 ├── config/                     # Application configurations
 │   ├── nvim/                   # Neovim / LazyVim configuration
+│   ├── codex/
+│   │   └── AGENTS.md           # Global Codex guidance
 │   ├── tmux.conf               # Tmux configuration
 │   └── vscode/                 # VS Code settings
 │       ├── extensions.txt      # Recommended extensions

--- a/config/codex/AGENTS.md
+++ b/config/codex/AGENTS.md
@@ -16,6 +16,13 @@
 - For Java, use SDKMAN-managed Java, Maven, and Gradle when available.
 - Use the repository's existing formatter, linter, test runner, and package manager rather than substituting equivalents.
 
+## Docker and WSL
+
+- This machine is WSL on Windows. Docker is expected to be provided by Docker Desktop on the Windows side.
+- If Docker is unavailable from WSL, check whether Docker Desktop is running before concluding Docker is not installed.
+- Prefer starting Docker Desktop from WSL and retrying the Docker command, for example with `powershell.exe -NoProfile -Command "Start-Process 'Docker Desktop'"`.
+- Do not install Docker directly inside WSL unless explicitly asked. Some people use that setup, but this machine's default is Windows Docker Desktop with WSL integration.
+
 ## Verification
 
 - Run the narrowest relevant formatter, typecheck, lint, and tests after code changes.

--- a/config/codex/AGENTS.md
+++ b/config/codex/AGENTS.md
@@ -6,17 +6,29 @@
 - Keep edits scoped to the requested behavior. Avoid unrelated refactors and dependency churn.
 - If the worktree already has changes, treat them as user work and do not revert them unless explicitly asked.
 - Prefer small, reviewable changes with focused verification over broad rewrites.
-- Commit frequently at discrete logical milestones when working on a branch.
-- Use Conventional Commits for all commit messages, for example `feat: add user onboarding`, `fix: handle missing config`, or `docs: update setup notes`.
+- Commit frequently at discrete logical milestones when working on a branch, using Conventional Commits.
+
+## Steering
+
+Read these opinionated global steering docs only when the task touches the relevant area:
+
+- Monorepos, Nx, and `just`: `~/dotfiles/config/codex/steering/monorepos.md`
+- TypeScript, pnpm, Biome, Vite, and TanStack: `~/dotfiles/config/codex/steering/typescript.md`
+- Python, uv, Ruff, and ty: `~/dotfiles/config/codex/steering/python.md`
+- Go and protobuf tooling: `~/dotfiles/config/codex/steering/go.md`
+- Java, SDKMAN, Maven, Gradle, and Checkstyle: `~/dotfiles/config/codex/steering/java.md`
+- Git workflow and commits: `~/dotfiles/config/codex/steering/git.md`
+- Testing and verification: `~/dotfiles/config/codex/steering/testing.md`
+- Generated code: `~/dotfiles/config/codex/steering/codegen.md`
+- Docker on WSL: `~/dotfiles/config/codex/steering/docker-wsl.md`
+- Frontend application work: `~/dotfiles/config/codex/steering/frontend.md`
+
+Do not read every steering doc by default.
 
 ## Toolchains
 
-- For TypeScript and JavaScript, prefer `pnpm` and respect pnpm workspaces. Use `biome` for linting/formatting.
-- For browser SPAs, prefer Vite and TanStack Router unless the repository clearly uses another stack.
-- Use nvm-managed Node versions. Check `.nvmrc`, `packageManager`, lockfiles, and workspace files before changing Node tooling.
-- For Python, use `uv` for dependency management, virtual environments, scripts, and workspaces. use `ruff` and `ty` for linting and typechecking.
-- For Java, use SDKMAN-managed Java, Maven, and Gradle when available. Use `checkstyle` for linting.
-- Use the repository's existing formatter, linter, test runner, and package manager rather than substituting equivalents.
+- Prefer repo-provided commands and existing toolchain choices over substituting equivalents.
+- Use `uv` for Python work, `pnpm` for TypeScript and JavaScript work, and SDKMAN-managed Java tooling when Java is involved.
 
 ## Current Documentation
 
@@ -24,16 +36,6 @@
 - Prefer Context7 over web search for API syntax, configuration, setup instructions, migrations, and library-specific debugging.
 - Do not use Context7 for general programming concepts, business-logic debugging, code review, refactoring, or writing scripts from scratch.
 - Start by resolving the library ID, choose the best matching source, then query docs with the user's full question. Use version-specific docs when the user names a version.
-
-## Docker and WSL
-
-- This machine is WSL on Windows. Docker is expected to be provided by Docker Desktop on the Windows side.
-- If Docker is unavailable from WSL, check whether Docker Desktop is running before concluding Docker is not installed.
-- The tested WSL command to start Docker Desktop is `/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoProfile -Command "Start-Process -FilePath 'C:\Program Files\Docker\Docker\Docker Desktop.exe'"`.
-- After starting Docker Desktop, poll with `docker ps` until the daemon is ready. If Codex sandboxing reports permission denied on `/var/run/docker.sock`, retry the Docker command with escalated permissions.
-- If the WSL `docker` command is missing or broken, the tested Windows Docker CLI path is `/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe`.
-- Docker Compose is also available from Windows at `/mnt/c/Program Files/Docker/Docker/resources/bin/docker-compose.exe`.
-- Do not install Docker directly inside WSL unless explicitly asked. Some people use that setup, but this machine's default is Windows Docker Desktop with WSL integration.
 
 ## Verification
 

--- a/config/codex/AGENTS.md
+++ b/config/codex/AGENTS.md
@@ -11,11 +11,11 @@
 
 ## Toolchains
 
-- For TypeScript and JavaScript, prefer `pnpm` and respect pnpm workspaces.
+- For TypeScript and JavaScript, prefer `pnpm` and respect pnpm workspaces. Use `biome` for linting/formatting.
 - For browser SPAs, prefer Vite and TanStack Router unless the repository clearly uses another stack.
 - Use nvm-managed Node versions. Check `.nvmrc`, `packageManager`, lockfiles, and workspace files before changing Node tooling.
-- For Python, prefer `uv` for dependency management, virtual environments, scripts, and workspaces.
-- For Java, use SDKMAN-managed Java, Maven, and Gradle when available.
+- For Python, use `uv` for dependency management, virtual environments, scripts, and workspaces. use `ruff` and `ty` for linting and typechecking.
+- For Java, use SDKMAN-managed Java, Maven, and Gradle when available. Use `checkstyle` for linting.
 - Use the repository's existing formatter, linter, test runner, and package manager rather than substituting equivalents.
 
 ## Current Documentation

--- a/config/codex/AGENTS.md
+++ b/config/codex/AGENTS.md
@@ -23,7 +23,7 @@ Read these opinionated global steering docs only when the task touches the relev
 - Docker on WSL: `~/dotfiles/config/codex/steering/docker-wsl.md`
 - Frontend application work: `~/dotfiles/config/codex/steering/frontend.md`
 
-Do not read every steering doc by default.
+Do not read every steering doc by default. Steering docs include frontmatter; use `applies_when` and `tags` as routing hints. Direct user instructions and repo-local `AGENTS.md` files override these global docs.
 
 ## Toolchains
 

--- a/config/codex/AGENTS.md
+++ b/config/codex/AGENTS.md
@@ -18,6 +18,13 @@
 - For Java, use SDKMAN-managed Java, Maven, and Gradle when available.
 - Use the repository's existing formatter, linter, test runner, and package manager rather than substituting equivalents.
 
+## Current Documentation
+
+- Use Context7 MCP for current documentation when the user asks about a library, framework, SDK, API, CLI tool, or cloud service.
+- Prefer Context7 over web search for API syntax, configuration, setup instructions, migrations, and library-specific debugging.
+- Do not use Context7 for general programming concepts, business-logic debugging, code review, refactoring, or writing scripts from scratch.
+- Start by resolving the library ID, choose the best matching source, then query docs with the user's full question. Use version-specific docs when the user names a version.
+
 ## Docker and WSL
 
 - This machine is WSL on Windows. Docker is expected to be provided by Docker Desktop on the Windows side.

--- a/config/codex/AGENTS.md
+++ b/config/codex/AGENTS.md
@@ -20,7 +20,10 @@
 
 - This machine is WSL on Windows. Docker is expected to be provided by Docker Desktop on the Windows side.
 - If Docker is unavailable from WSL, check whether Docker Desktop is running before concluding Docker is not installed.
-- Prefer starting Docker Desktop from WSL and retrying the Docker command, for example with `powershell.exe -NoProfile -Command "Start-Process 'Docker Desktop'"`.
+- The tested WSL command to start Docker Desktop is `/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoProfile -Command "Start-Process -FilePath 'C:\Program Files\Docker\Docker\Docker Desktop.exe'"`.
+- After starting Docker Desktop, poll with `docker ps` until the daemon is ready. If Codex sandboxing reports permission denied on `/var/run/docker.sock`, retry the Docker command with escalated permissions.
+- If the WSL `docker` command is missing or broken, the tested Windows Docker CLI path is `/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe`.
+- Docker Compose is also available from Windows at `/mnt/c/Program Files/Docker/Docker/resources/bin/docker-compose.exe`.
 - Do not install Docker directly inside WSL unless explicitly asked. Some people use that setup, but this machine's default is Windows Docker Desktop with WSL integration.
 
 ## Verification

--- a/config/codex/AGENTS.md
+++ b/config/codex/AGENTS.md
@@ -6,6 +6,8 @@
 - Keep edits scoped to the requested behavior. Avoid unrelated refactors and dependency churn.
 - If the worktree already has changes, treat them as user work and do not revert them unless explicitly asked.
 - Prefer small, reviewable changes with focused verification over broad rewrites.
+- Commit frequently at discrete logical milestones when working on a branch.
+- Use Conventional Commits for all commit messages, for example `feat: add user onboarding`, `fix: handle missing config`, or `docs: update setup notes`.
 
 ## Toolchains
 

--- a/config/codex/AGENTS.md
+++ b/config/codex/AGENTS.md
@@ -1,0 +1,23 @@
+# Global Codex Guidance
+
+## Working Agreements
+
+- Read the repository before making assumptions, and follow existing patterns before introducing new ones.
+- Keep edits scoped to the requested behavior. Avoid unrelated refactors and dependency churn.
+- If the worktree already has changes, treat them as user work and do not revert them unless explicitly asked.
+- Prefer small, reviewable changes with focused verification over broad rewrites.
+
+## Toolchains
+
+- For TypeScript and JavaScript, prefer `pnpm` and respect pnpm workspaces.
+- For browser SPAs, prefer Vite and TanStack Router unless the repository clearly uses another stack.
+- Use nvm-managed Node versions. Check `.nvmrc`, `packageManager`, lockfiles, and workspace files before changing Node tooling.
+- For Python, prefer `uv` for dependency management, virtual environments, scripts, and workspaces.
+- For Java, use SDKMAN-managed Java, Maven, and Gradle when available.
+- Use the repository's existing formatter, linter, test runner, and package manager rather than substituting equivalents.
+
+## Verification
+
+- Run the narrowest relevant formatter, typecheck, lint, and tests after code changes.
+- If full verification is expensive or blocked, run the closest focused check and clearly state what did and did not run.
+- Do not claim work is complete without fresh verification evidence from this machine.

--- a/config/codex/steering/README.md
+++ b/config/codex/steering/README.md
@@ -1,0 +1,7 @@
+# Codex Steering
+
+These files hold opinionated global defaults for how work should be done on this machine.
+
+`AGENTS.md` is the always-loaded router. Keep it short. Read only the steering files relevant to the current task, and let repo-local `AGENTS.md` files override these defaults when a project has stricter rules.
+
+Use steering docs for durable preferences. Use skills for repeatable workflows that need step-by-step execution.

--- a/config/codex/steering/README.md
+++ b/config/codex/steering/README.md
@@ -1,3 +1,15 @@
+---
+title: Codex Steering Index
+description: Explains how global Codex steering docs are organized and when to use them.
+applies_when:
+  - Navigating global steering docs
+  - Deciding whether to add a steering doc or a skill
+tags:
+  - codex
+  - steering
+  - index
+---
+
 # Codex Steering
 
 These files hold opinionated global defaults for how work should be done on this machine.

--- a/config/codex/steering/codegen.md
+++ b/config/codex/steering/codegen.md
@@ -1,3 +1,17 @@
+---
+title: Codegen Steering
+description: Opinionated defaults for generated code and freshness checks.
+applies_when:
+  - Generated code changes
+  - OpenAPI, protobuf, route tree, or API client updates
+  - Codegen drift or freshness checks
+tags:
+  - codegen
+  - generated-code
+  - openapi
+  - protobuf
+---
+
 # Codegen Steering
 
 - Treat generated code as derived output.

--- a/config/codex/steering/codegen.md
+++ b/config/codex/steering/codegen.md
@@ -1,0 +1,7 @@
+# Codegen Steering
+
+- Treat generated code as derived output.
+- Do not hand-edit generated clients, protobuf stubs, route trees, OpenAPI output, or similar artifacts.
+- Find and run the owning codegen command instead.
+- After codegen, inspect the generated diff and verify it is limited to expected outputs.
+- If an API schema changes, check downstream generated clients and freshness checks.

--- a/config/codex/steering/docker-wsl.md
+++ b/config/codex/steering/docker-wsl.md
@@ -1,3 +1,16 @@
+---
+title: Docker and WSL Steering
+description: Machine-specific Docker Desktop guidance for WSL on Windows.
+applies_when:
+  - Docker commands from WSL
+  - Docker Desktop is unavailable or not running
+  - Docker socket permission or sandbox issues
+tags:
+  - docker
+  - wsl
+  - windows
+---
+
 # Docker and WSL Steering
 
 - This machine is WSL on Windows. Docker is expected to be provided by Docker Desktop on the Windows side.

--- a/config/codex/steering/docker-wsl.md
+++ b/config/codex/steering/docker-wsl.md
@@ -1,0 +1,10 @@
+# Docker and WSL Steering
+
+- This machine is WSL on Windows. Docker is expected to be provided by Docker Desktop on the Windows side.
+- If Docker is unavailable from WSL, check whether Docker Desktop is running before concluding Docker is not installed.
+- The tested WSL command to start Docker Desktop is `/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoProfile -Command "Start-Process -FilePath 'C:\Program Files\Docker\Docker\Docker Desktop.exe'"`.
+- After starting Docker Desktop, poll with `docker ps` until the daemon is ready.
+- If Codex sandboxing reports permission denied on `/var/run/docker.sock`, retry the Docker command with escalated permissions.
+- If the WSL `docker` command is missing or broken, the tested Windows Docker CLI path is `/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe`.
+- Docker Compose is also available from Windows at `/mnt/c/Program Files/Docker/Docker/resources/bin/docker-compose.exe`.
+- Do not install Docker directly inside WSL unless explicitly asked. Some people use that setup, but this machine's default is Windows Docker Desktop with WSL integration.

--- a/config/codex/steering/frontend.md
+++ b/config/codex/steering/frontend.md
@@ -1,0 +1,8 @@
+# Frontend Steering
+
+- Build the actual usable application experience first, not a marketing landing page, unless the user explicitly asks for a landing page.
+- For operational tools, prefer dense, calm, task-focused UI over decorative marketing composition.
+- Use established project components and design conventions before adding new abstractions.
+- Use icons for common tool actions when an icon library is already present.
+- Verify responsive layout for text fit, overlapping UI, and primary workflows.
+- For SPAs, prefer route-driven structure and data-loading patterns already established in the repo.

--- a/config/codex/steering/frontend.md
+++ b/config/codex/steering/frontend.md
@@ -1,3 +1,22 @@
+---
+title: Frontend Steering
+description: Opinionated defaults for frontend app architecture, routing, data fetching, validation, and styling.
+applies_when:
+  - Frontend app setup
+  - SPA architecture or routing work
+  - React feature organization
+  - Frontend styling decisions
+tags:
+  - frontend
+  - react
+  - spa
+  - vite
+  - tanstack-router
+  - tanstack-query
+  - zod
+  - css
+---
+
 # Frontend Steering
 
 - Build the actual usable application experience first, not a marketing landing page, unless the user explicitly asks for a landing page.

--- a/config/codex/steering/frontend.md
+++ b/config/codex/steering/frontend.md
@@ -2,6 +2,11 @@
 
 - Build the actual usable application experience first, not a marketing landing page, unless the user explicitly asks for a landing page.
 - For operational tools, prefer dense, calm, task-focused UI over decorative marketing composition.
+- Prefer SPA applications named or organized around `spa` unless the repo already has a different established frontend app shape.
+- Use Bulletproof React conventions for feature organization, shared components, app providers, routing, and API boundaries.
+- Prefer Vite, React, TanStack Router, TanStack Query, and Zod for new frontend app work.
+- Never choose Next.js for new projects or rewrites unless explicitly instructed.
+- Prefer modern CSS over Tailwind CSS v4 for new styling work unless the repo already depends on Tailwind.
 - Use established project components and design conventions before adding new abstractions.
 - Use icons for common tool actions when an icon library is already present.
 - Verify responsive layout for text fit, overlapping UI, and primary workflows.

--- a/config/codex/steering/git.md
+++ b/config/codex/steering/git.md
@@ -1,3 +1,18 @@
+---
+title: Git Steering
+description: Opinionated defaults for branches, commits, staging, and PR-oriented work.
+applies_when:
+  - Git commits
+  - Branch or PR work
+  - Staging files
+  - Publishing changes
+tags:
+  - git
+  - conventional-commits
+  - branches
+  - pull-requests
+---
+
 # Git Steering
 
 - Commit frequently at discrete logical milestones when working on a branch.

--- a/config/codex/steering/git.md
+++ b/config/codex/steering/git.md
@@ -1,0 +1,15 @@
+# Git Steering
+
+- Commit frequently at discrete logical milestones when working on a branch.
+- Use Conventional Commits for all commit messages.
+- Prefer small, reviewable commits over broad mixed-purpose commits.
+- Do not stage unrelated user changes.
+- Do not push directly to `main`; use a feature branch and PR.
+- Before committing, review the staged diff and run the narrowest relevant verification.
+
+Examples:
+
+- `feat: add dashboard filters`
+- `fix(api): handle missing stats rows`
+- `docs: update local setup notes`
+- `test: cover generated client errors`

--- a/config/codex/steering/go.md
+++ b/config/codex/steering/go.md
@@ -1,0 +1,6 @@
+# Go Steering
+
+- Use the repo's Go workspace or module files as the source of truth.
+- Prefer `go test ./...` and `go vet ./...` for broad checks when the repo does not provide narrower commands.
+- Use Buf for Protocol Buffers linting, formatting, and generation when present.
+- Do not edit generated Go protobuf outputs by hand. Regenerate them through the repo's codegen target.

--- a/config/codex/steering/go.md
+++ b/config/codex/steering/go.md
@@ -1,3 +1,16 @@
+---
+title: Go Steering
+description: Opinionated defaults for Go modules, workspaces, tests, vetting, and protobuf tooling.
+applies_when:
+  - Go project changes
+  - Go tests or vetting
+  - Go protobuf generation
+tags:
+  - go
+  - protobuf
+  - buf
+---
+
 # Go Steering
 
 - Use the repo's Go workspace or module files as the source of truth.

--- a/config/codex/steering/go.md
+++ b/config/codex/steering/go.md
@@ -1,12 +1,16 @@
 ---
 title: Go Steering
-description: Opinionated defaults for Go modules, workspaces, tests, vetting, and protobuf tooling.
+description: Opinionated defaults for Go modules, workspaces, service structure, tests, vetting, and protobuf tooling.
 applies_when:
+  - Go project setup
   - Go project changes
+  - Go service development
   - Go tests or vetting
   - Go protobuf generation
 tags:
   - go
+  - go-work
+  - go-modules
   - protobuf
   - buf
 ---
@@ -14,6 +18,16 @@ tags:
 # Go Steering
 
 - Use the repo's Go workspace or module files as the source of truth.
+- Prefer standard library packages until a dependency clearly pays for itself.
+- Keep Go services boring and explicit: small packages, clear interfaces at boundaries, context-aware APIs, and errors returned rather than hidden.
+- Use `cmd/<service>` for executable entry points and keep domain/application logic outside `main`.
+- Prefer structured logging with `log/slog` unless the repo has already standardized on another logger.
+- Use environment-based configuration with typed config structs. Avoid global mutable config.
+- Always run `gofmt` or `go fmt ./...` after editing Go files.
 - Prefer `go test ./...` and `go vet ./...` for broad checks when the repo does not provide narrower commands.
+- Add table-driven tests for branching business logic and boundary behavior.
+- Use `errors.Is`, `errors.As`, and error wrapping with `%w` for inspectable errors.
+- Keep concurrency simple. Use `context.Context`, bounded goroutines, and clear cancellation paths.
+- Manage dependencies with `go mod tidy` after changing imports or module metadata.
 - Use Buf for Protocol Buffers linting, formatting, and generation when present.
 - Do not edit generated Go protobuf outputs by hand. Regenerate them through the repo's codegen target.

--- a/config/codex/steering/java.md
+++ b/config/codex/steering/java.md
@@ -1,16 +1,20 @@
 ---
 title: Java Steering
-description: Opinionated defaults for Java tooling through SDKMAN, Maven, Gradle, and Checkstyle.
+description: Opinionated defaults for Java tooling, Spring Boot services, build tools, tests, and style.
 applies_when:
+  - Java project setup
   - Java project changes
+  - Spring Boot service development
   - Maven or Gradle work
   - Java linting or tests
 tags:
   - java
   - sdkman
+  - spring-boot
   - maven
   - gradle
   - checkstyle
+  - junit
 ---
 
 # Java Steering
@@ -19,3 +23,15 @@ tags:
 - Use the repository's Maven or Gradle wrapper/configuration instead of introducing another build path.
 - Use Checkstyle when present.
 - Prefer the repo's existing `test`, `compile`, `check`, or equivalent targets before inventing new Java commands.
+- Prefer modern LTS Java versions when starting new work, unless the repo pins a different version.
+- Prefer Spring Boot for Java service APIs unless the repo already uses another framework.
+- Keep Java services layered and explicit: controller/resource, service/application, repository/gateway, configuration, and domain packages.
+- Use constructor injection. Avoid field injection.
+- Prefer records for immutable DTOs and value carriers.
+- Use Jakarta validation annotations for request/config validation when applicable.
+- Use typed configuration properties instead of scattered direct environment lookups.
+- Prefer SLF4J-compatible structured logging. Do not use `System.out` for application logging.
+- Use JUnit 5 for tests. Add focused unit tests for service logic and integration tests for framework/database boundaries.
+- Do not mix Maven and Gradle in the same project unless the repository already does.
+- Do not add Lombok by default. Prefer explicit Java language features unless the repo has already standardized on Lombok.
+- Keep generated Java sources out of hand edits. Regenerate through the repo's build or codegen task.

--- a/config/codex/steering/java.md
+++ b/config/codex/steering/java.md
@@ -1,0 +1,6 @@
+# Java Steering
+
+- Use SDKMAN-managed Java tooling on this machine.
+- Use the repository's Maven or Gradle wrapper/configuration instead of introducing another build path.
+- Use Checkstyle when present.
+- Prefer the repo's existing `test`, `compile`, `check`, or equivalent targets before inventing new Java commands.

--- a/config/codex/steering/java.md
+++ b/config/codex/steering/java.md
@@ -1,3 +1,18 @@
+---
+title: Java Steering
+description: Opinionated defaults for Java tooling through SDKMAN, Maven, Gradle, and Checkstyle.
+applies_when:
+  - Java project changes
+  - Maven or Gradle work
+  - Java linting or tests
+tags:
+  - java
+  - sdkman
+  - maven
+  - gradle
+  - checkstyle
+---
+
 # Java Steering
 
 - Use SDKMAN-managed Java tooling on this machine.

--- a/config/codex/steering/monorepos.md
+++ b/config/codex/steering/monorepos.md
@@ -1,3 +1,17 @@
+---
+title: Monorepo Steering
+description: Opinionated defaults for workspace-oriented repositories and build orchestration.
+applies_when:
+  - Monorepo setup or maintenance
+  - Nx, just, or workspace command changes
+  - Cross-package checks or affected-project workflows
+tags:
+  - monorepo
+  - nx
+  - just
+  - workspaces
+---
+
 # Monorepo Steering
 
 - Prefer a single command runner as the front door when a repo provides one, especially `just`.

--- a/config/codex/steering/monorepos.md
+++ b/config/codex/steering/monorepos.md
@@ -1,0 +1,8 @@
+# Monorepo Steering
+
+- Prefer a single command runner as the front door when a repo provides one, especially `just`.
+- In mixed-language repos, prefer workspace-aware commands over per-package ad hoc installs.
+- Prefer affected-project checks when the repo supports them through Nx or similar tooling.
+- Respect project graph metadata, target dependencies, and generated-code outputs before changing build orchestration.
+- Use root workspace manifests as the source of truth for package manager and runtime versions.
+- Do not introduce naming conventions from one repo into another repo unless the user explicitly asks for that convention.

--- a/config/codex/steering/python.md
+++ b/config/codex/steering/python.md
@@ -6,4 +6,8 @@
 - Use Ruff for linting and formatting when present.
 - Use `ty` for typechecking when present.
 - In uv workspaces, add dependencies to the owning package rather than the workspace root unless the dependency is genuinely shared tooling.
-- Avoid relative imports in Python packages when the repo enforces absolute imports.
+- Use absolute imports for package structure. Avoid relative imports.
+- Use Polars when dataframe-style work is needed.
+- Use FastAPI for Python APIs, served with Uvicorn or Gunicorn depending on the deployment shape.
+- Prefer Pydantic v2 models over dataclasses for validation, settings, DTOs, and structured API/domain boundaries.
+- Build a common/shared package early in Python projects for cross-cutting concerns such as logging, configuration, database connections, DTOs, and domain models.

--- a/config/codex/steering/python.md
+++ b/config/codex/steering/python.md
@@ -1,12 +1,13 @@
 ---
 title: Python Steering
-description: Opinionated defaults for Python projects, uv workspaces, APIs, dataframes, and shared packages.
+description: Opinionated defaults for Python projects, uv workspaces, package structure, APIs, dataframes, and shared packages.
 applies_when:
   - Python project setup
   - Python package changes
   - Python API work
   - Dataframe or ETL work
   - Python shared package design
+  - Python testing, linting, or typechecking
 tags:
   - python
   - uv
@@ -22,11 +23,21 @@ tags:
 - Use `uv` for dependency management, virtual environments, scripts, and workspaces.
 - Prefer `uv run ...` over calling Python tools directly.
 - Prefer `uv add`, `uv sync`, and `uv run --package <name> ...` over `pip`, manually managed virtualenvs, or direct `.venv` invocation.
+- Prefer uv workspaces for multi-package Python projects.
+- Keep Python packages importable and explicit. Use `src` or package-root layouts already established by the repo, and avoid script-only architecture for application code.
 - Use Ruff for linting and formatting when present.
 - Use `ty` for typechecking when present.
+- Treat linting, formatting, and typechecking as separate verification signals.
 - In uv workspaces, add dependencies to the owning package rather than the workspace root unless the dependency is genuinely shared tooling.
 - Use absolute imports for package structure. Avoid relative imports.
+- Use `pytest` for tests unless the repo has standardized on another runner.
+- Prefer async-capable tests for async code instead of hiding event-loop behavior behind sync wrappers.
 - Use Polars when dataframe-style work is needed.
 - Use FastAPI for Python APIs, served with Uvicorn or Gunicorn depending on the deployment shape.
+- Keep FastAPI apps modular: app creation, routes, dependencies, settings, and persistence should not all live in one file once the project grows.
 - Prefer Pydantic v2 models over dataclasses for validation, settings, DTOs, and structured API/domain boundaries.
+- Use `pydantic-settings` or typed settings models for configuration. Avoid scattered direct environment lookups.
 - Build a common/shared package early in Python projects for cross-cutting concerns such as logging, configuration, database connections, DTOs, and domain models.
+- Prefer structured logging and shared logging setup over per-module ad hoc logger configuration.
+- Keep database/session lifecycle management centralized in shared infrastructure code.
+- Do not hand-edit generated Python protobuf, OpenAPI, or client outputs. Regenerate them through the repo's codegen command.

--- a/config/codex/steering/python.md
+++ b/config/codex/steering/python.md
@@ -1,0 +1,9 @@
+# Python Steering
+
+- Use `uv` for dependency management, virtual environments, scripts, and workspaces.
+- Prefer `uv run ...` over calling Python tools directly.
+- Prefer `uv add`, `uv sync`, and `uv run --package <name> ...` over `pip`, manually managed virtualenvs, or direct `.venv` invocation.
+- Use Ruff for linting and formatting when present.
+- Use `ty` for typechecking when present.
+- In uv workspaces, add dependencies to the owning package rather than the workspace root unless the dependency is genuinely shared tooling.
+- Avoid relative imports in Python packages when the repo enforces absolute imports.

--- a/config/codex/steering/python.md
+++ b/config/codex/steering/python.md
@@ -1,3 +1,22 @@
+---
+title: Python Steering
+description: Opinionated defaults for Python projects, uv workspaces, APIs, dataframes, and shared packages.
+applies_when:
+  - Python project setup
+  - Python package changes
+  - Python API work
+  - Dataframe or ETL work
+  - Python shared package design
+tags:
+  - python
+  - uv
+  - ruff
+  - ty
+  - fastapi
+  - pydantic
+  - polars
+---
+
 # Python Steering
 
 - Use `uv` for dependency management, virtual environments, scripts, and workspaces.

--- a/config/codex/steering/testing.md
+++ b/config/codex/steering/testing.md
@@ -1,3 +1,19 @@
+---
+title: Testing and Verification Steering
+description: Opinionated defaults for choosing and reporting verification commands.
+applies_when:
+  - Running tests
+  - Running lint, format, or typecheck
+  - Verifying codegen freshness
+  - Reporting verification status
+tags:
+  - testing
+  - verification
+  - linting
+  - typechecking
+  - codegen
+---
+
 # Testing and Verification Steering
 
 - Run the narrowest relevant formatter, typecheck, lint, and tests after code changes.

--- a/config/codex/steering/testing.md
+++ b/config/codex/steering/testing.md
@@ -1,11 +1,12 @@
 ---
 title: Testing and Verification Steering
-description: Opinionated defaults for choosing and reporting verification commands.
+description: Opinionated defaults for choosing, sequencing, and reporting verification commands.
 applies_when:
   - Running tests
   - Running lint, format, or typecheck
   - Verifying codegen freshness
   - Reporting verification status
+  - Choosing focused versus broad checks
 tags:
   - testing
   - verification
@@ -18,6 +19,14 @@ tags:
 
 - Run the narrowest relevant formatter, typecheck, lint, and tests after code changes.
 - Prefer repo-provided commands such as `just check`, `just test`, Nx targets, package filters, or affected checks.
+- Use focused checks first while iterating, then run broader repo-level or affected checks before committing or claiming completion.
+- For TypeScript changes, include formatting/linting, typechecking, and relevant tests.
+- For Python changes, include Ruff format/check, `ty` when present, and relevant pytest targets.
+- For Go changes, include `go fmt`, `go vet`, and relevant `go test` targets.
+- For Java changes, include the repo's compile/check target and relevant JUnit tests.
 - For generated code, run the codegen command and check for drift.
+- When fixing a bug, prefer adding or updating a regression test that fails before the fix and passes after it when practical.
+- Verify the actual user-facing path when the change affects UI, API behavior, CLI behavior, Docker startup, or generated artifacts.
 - If full verification is expensive or blocked, run the closest focused check and clearly state what did and did not run.
+- Report verification with command names and outcomes, not vague statements.
 - Do not claim work is complete without fresh verification evidence from this machine.

--- a/config/codex/steering/testing.md
+++ b/config/codex/steering/testing.md
@@ -1,0 +1,7 @@
+# Testing and Verification Steering
+
+- Run the narrowest relevant formatter, typecheck, lint, and tests after code changes.
+- Prefer repo-provided commands such as `just check`, `just test`, Nx targets, package filters, or affected checks.
+- For generated code, run the codegen command and check for drift.
+- If full verification is expensive or blocked, run the closest focused check and clearly state what did and did not run.
+- Do not claim work is complete without fresh verification evidence from this machine.

--- a/config/codex/steering/typescript.md
+++ b/config/codex/steering/typescript.md
@@ -1,0 +1,9 @@
+# TypeScript Steering
+
+- Prefer `pnpm` and respect pnpm workspaces.
+- Prefer Vite and TanStack Router for browser SPAs unless the repository already uses another stack.
+- Check `.nvmrc`, `packageManager`, lockfiles, and workspace files before changing Node tooling.
+- Use Biome for linting and formatting when present.
+- Use the repo's TypeScript checker command. If the repo uses `tsgo`, keep using it.
+- Prefer workspace filters such as `pnpm --filter <package> ...` for package-specific work.
+- Do not hand-edit generated route trees, generated API clients, or other generated TypeScript outputs. Regenerate them through the repo's codegen command.

--- a/config/codex/steering/typescript.md
+++ b/config/codex/steering/typescript.md
@@ -1,10 +1,12 @@
 ---
 title: TypeScript Steering
-description: Opinionated defaults for TypeScript and JavaScript workspaces, SPAs, Biome, and generated TypeScript.
+description: Opinionated defaults for TypeScript and JavaScript workspaces, app structure, SPAs, Biome, validation, data fetching, and generated TypeScript.
 applies_when:
   - TypeScript or JavaScript project changes
+  - TypeScript project setup
   - pnpm workspace work
   - Vite or TanStack Router work
+  - TanStack Query or Zod work
   - Biome linting or formatting
   - Generated TypeScript updates
 tags:
@@ -14,6 +16,8 @@ tags:
   - biome
   - vite
   - tanstack-router
+  - tanstack-query
+  - zod
 ---
 
 # TypeScript Steering
@@ -21,7 +25,15 @@ tags:
 - Prefer `pnpm` and respect pnpm workspaces.
 - Prefer Vite and TanStack Router for browser SPAs unless the repository already uses another stack.
 - Check `.nvmrc`, `packageManager`, lockfiles, and workspace files before changing Node tooling.
+- Prefer strict TypeScript. Avoid `any`; model unknown data at boundaries and narrow it with validation.
 - Use Biome for linting and formatting when present.
 - Use the repo's TypeScript checker command. If the repo uses `tsgo`, keep using it.
 - Prefer workspace filters such as `pnpm --filter <package> ...` for package-specific work.
+- Prefer Bulletproof React-style feature organization for React apps: app providers/routing at the top, feature modules for product behavior, shared components/utilities for reusable primitives, and API clients isolated from UI components.
+- Use TanStack Router for route structure and route-level data boundaries when building SPAs.
+- Use TanStack Query for server-state fetching, caching, mutations, retries, and invalidation. Do not replace it with ad hoc `useEffect` fetch flows.
+- Use Zod for runtime validation at external boundaries such as API responses, forms, URL/search params, environment/config, and local storage.
+- Keep form, API, and domain DTO types explicit. Avoid letting component props become the only data model.
+- Prefer modern CSS for new styling work unless the repo already uses a specific styling system.
+- Keep generated clients and route artifacts separated from hand-written source when possible.
 - Do not hand-edit generated route trees, generated API clients, or other generated TypeScript outputs. Regenerate them through the repo's codegen command.

--- a/config/codex/steering/typescript.md
+++ b/config/codex/steering/typescript.md
@@ -1,3 +1,21 @@
+---
+title: TypeScript Steering
+description: Opinionated defaults for TypeScript and JavaScript workspaces, SPAs, Biome, and generated TypeScript.
+applies_when:
+  - TypeScript or JavaScript project changes
+  - pnpm workspace work
+  - Vite or TanStack Router work
+  - Biome linting or formatting
+  - Generated TypeScript updates
+tags:
+  - typescript
+  - javascript
+  - pnpm
+  - biome
+  - vite
+  - tanstack-router
+---
+
 # TypeScript Steering
 
 - Prefer `pnpm` and respect pnpm workspaces.

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ log_success "Created $BACKUP_DIR"
 
 # Backup existing files
 log_step 2 "Backing up existing configuration..."
-for file in .bashrc .bash_aliases .bash_functions .bash_paths .bash_logger .tmux.conf; do
+for file in .bashrc .bash_aliases .bash_functions .bash_paths .bash_logger .tmux.conf .codex/AGENTS.md; do
     if [ -f "$HOME/$file" ] || [ -L "$HOME/$file" ]; then
         log_detail "Backing up $HOME/$file"
         mv "$HOME/$file" "$BACKUP_DIR/"
@@ -72,6 +72,7 @@ install_files "$DOTFILES_DIR/bash/bash_functions" "$HOME/.bash_functions"
 install_files "$DOTFILES_DIR/bash/bash_paths" "$HOME/.bash_paths"
 install_files "$DOTFILES_DIR/bash/bash_logger" "$HOME/.bash_logger"
 install_files "$DOTFILES_DIR/config/tmux.conf" "$HOME/.tmux.conf"
+install_files "$DOTFILES_DIR/config/codex/AGENTS.md" "$HOME/.codex/AGENTS.md"
 
 # Create secrets file from template if it doesn't exist
 if [ ! -f "$HOME/.bash_secrets" ]; then

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -54,6 +54,7 @@ docker run --rm -e DOTFILES_CI=1 "${IMAGE_NAME}:installed" bash -c '
     check "~/.bashrc is a symlink"       test -L ~/.bashrc
     check "~/.bash_aliases is a symlink"  test -L ~/.bash_aliases
     check "~/.tmux.conf is a symlink"     test -L ~/.tmux.conf
+    check "~/.codex/AGENTS.md is a symlink" test -L ~/.codex/AGENTS.md
 
     echo "--- Tools on PATH ---"
     check "node is on PATH"    command -v node


### PR DESCRIPTION
## Summary
- add global Codex steering guidance under config/codex/AGENTS.md
- install it to ~/.codex/AGENTS.md through install.sh
- document the Codex config location and extend the smoke test assertion

## Validation
- bash -n install.sh
- bash -n test/run-test.sh
- git diff --check

Note: the full Docker smoke test was not run because docker is not installed on this machine.