### PR TITLE
fix: restore PNPM_HOME so pnpm global installs work out of the box

### DIFF
--- a/bash/bashrc
+++ b/bash/bashrc
@@ -54,4 +54,3 @@ if [ -d "$HOME/.tool_configs" ]; then
     fi
   done
 fi
-

--- a/bash/tool_configs/node.sh
+++ b/bash/tool_configs/node.sh
@@ -51,6 +51,15 @@ if [ -s "$NVM_DIR/nvm.sh" ]; then
     }
 fi
 
-# pnpm is provided by corepack via the default node installation above.
-# No separate PNPM_HOME or PATH entry needed — the corepack shim lives
-# in the same bin directory as node/npm/npx.
+# =============================================================================
+# pnpm
+# =============================================================================
+# The `pnpm` binary itself is the corepack shim from the node install above.
+# PNPM_HOME is separate: it is where pnpm installs *global* packages
+# (`pnpm add -g`, `pnpm dlx` cache, etc.) and pnpm refuses to do global
+# installs without it being set and on PATH.
+export PNPM_HOME="$HOME/.local/share/pnpm"
+case ":$PATH:" in
+    *":$PNPM_HOME:"*) ;;
+    *) export PATH="$PNPM_HOME:$PATH" ;;
+esac

--- a/tools/setup_node.sh
+++ b/tools/setup_node.sh
@@ -40,6 +40,12 @@ ensure_pnpm() {
     corepack enable
     log_detail "Preparing pnpm@latest via corepack..."
     corepack prepare pnpm@latest --activate
+
+    # Pre-create PNPM_HOME so global installs (`pnpm add -g`) work without
+    # needing the user to run `pnpm setup` interactively. The PATH entry is
+    # set in bash/tool_configs/node.sh.
+    local pnpm_home="${PNPM_HOME:-$HOME/.local/share/pnpm}"
+    mkdir -p "$pnpm_home"
 }
 
 ensure_typescript() {


### PR DESCRIPTION
## Summary

- PR #12 removed `PNPM_HOME` on the assumption that the corepack shim made it redundant. The shim only handles the `pnpm` binary — `PNPM_HOME` is the install location for **global** packages (`pnpm add -g`, `pnpm dlx` shims), and pnpm refuses global installs without it set and on PATH.
- Without it, `pnpm` prompts the user to run `pnpm setup`, which appends an export block to `~/.bashrc`. Since `~/.bashrc` is a symlink into this repo, that band-aid mutates the dotfiles in the wrong spot (raw bashrc instead of the modular `tool_configs/node.sh`).
- Restore `PNPM_HOME` + PATH entry in `bash/tool_configs/node.sh` with a comment explaining the corepack-vs-PNPM_HOME distinction so this isn't deleted again.
- Have `tools/setup_node.sh` `mkdir -p "$PNPM_HOME"` so a fresh box never needs interactive `pnpm setup`.

## Test plan

- [x] `bash -n` on all three modified files
- [x] Sourcing `bash/tool_configs/node.sh` in a clean subshell exports `PNPM_HOME`, puts it on `PATH`, and `pnpm -v` resolves
- [ ] Run `tools/setup_node.sh` on a fresh machine (or with `~/.local/share/pnpm` removed) and confirm `pnpm add -g <pkg>` works without an interactive `pnpm setup` prompt