### PR TITLE
feat: pnpm 11 pin + restore PNPM_HOME for global installs

### DIFF
--- a/bash/bashrc
+++ b/bash/bashrc
@@ -54,4 +54,3 @@ if [ -d "$HOME/.tool_configs" ]; then
     fi
   done
 fi
-

--- a/bash/tool_configs/node.sh
+++ b/bash/tool_configs/node.sh
@@ -51,6 +51,15 @@ if [ -s "$NVM_DIR/nvm.sh" ]; then
     }
 fi
 
-# pnpm is provided by corepack via the default node installation above.
-# No separate PNPM_HOME or PATH entry needed — the corepack shim lives
-# in the same bin directory as node/npm/npx.
+# =============================================================================
+# pnpm
+# =============================================================================
+# The `pnpm` binary itself is the corepack shim from the node install above.
+# PNPM_HOME is separate: it is where pnpm installs *global* packages
+# (`pnpm add -g`, `pnpm dlx` cache, etc.) and pnpm refuses to do global
+# installs without it being set and on PATH.
+export PNPM_HOME="$HOME/.local/share/pnpm"
+case ":$PATH:" in
+    *":$PNPM_HOME:"*) ;;
+    *) export PATH="$PNPM_HOME:$PATH" ;;
+esac

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -76,6 +76,7 @@ docker run --rm -e DOTFILES_CI=1 "${IMAGE_NAME}:installed" bash -c '
     check "java runs"    java -version
     check "bun runs"     bun --version
     check "pnpm runs"    pnpm --version
+    check "pnpm is 11+"  bash -c "[ \"\$(pnpm --version | cut -d. -f1)\" -ge 11 ]"
 
     echo "--- Node visible to subprocesses ---"
     check "node found by env"  env which node

--- a/tools/setup_node.sh
+++ b/tools/setup_node.sh
@@ -67,6 +67,12 @@ ensure_pnpm() {
     fi
     log_detail "Preparing pnpm@$pnpm_version via corepack..."
     corepack prepare "pnpm@$pnpm_version" --activate
+
+    # Pre-create PNPM_HOME so global installs (`pnpm add -g`) work without
+    # needing the user to run `pnpm setup` interactively. The PATH entry is
+    # set in bash/tool_configs/node.sh.
+    local pnpm_home="${PNPM_HOME:-$HOME/.local/share/pnpm}"
+    mkdir -p "$pnpm_home"
 }
 
 ensure_typescript() {

--- a/tools/setup_node.sh
+++ b/tools/setup_node.sh
@@ -31,18 +31,22 @@ get_latest_nvm_version() {
     fi
 }
 
-# Minimum supported pnpm major version. Corepack's bundled `@latest` lags
-# behind npm (it ships a hardcoded "known good" map per Node release), so we
+# Target pnpm major version. Corepack's bundled `@latest` lags behind npm
+# (it ships a hardcoded "known good" version map per Node release), so we
 # resolve the actual latest in this major line from the npm registry.
-PNPM_MAJOR=11
+# Bare-major fallback (`pnpm@11`) is intentional: corepack resolves bare
+# majors against npm and bypasses the KGV map, so it stays current even if
+# the dist-tag fetch fails. Do not "simplify" the fallback back to
+# `pnpm@latest` — that re-introduces the stale-KGV bug.
+PNPM_TARGET_MAJOR=11
 
 get_latest_pnpm_version() {
     local major="$1"
     local version=""
     if command -v jq &> /dev/null; then
-        version=$(curl -s "https://registry.npmjs.org/-/package/pnpm/dist-tags" | jq -r ".\"latest-$major\"")
+        version=$(curl -s --connect-timeout 5 --max-time 10 "https://registry.npmjs.org/-/package/pnpm/dist-tags" | jq -r ".\"latest-$major\"")
     else
-        version=$(curl -s "https://registry.npmjs.org/-/package/pnpm/dist-tags" | grep -Po "\"latest-$major\"\s*:\s*\"\K[^\"]+")
+        version=$(curl -s --connect-timeout 5 --max-time 10 "https://registry.npmjs.org/-/package/pnpm/dist-tags" | grep -Po "\"latest-$major\"\s*:\s*\"\K[^\"]+")
     fi
     if [ -z "$version" ] || [ "$version" = "null" ]; then
         echo ""
@@ -60,10 +64,10 @@ ensure_pnpm() {
     corepack enable
 
     local pnpm_version
-    pnpm_version=$(get_latest_pnpm_version "$PNPM_MAJOR")
+    pnpm_version=$(get_latest_pnpm_version "$PNPM_TARGET_MAJOR")
     if [ -z "$pnpm_version" ]; then
-        log_detail "Could not resolve latest pnpm $PNPM_MAJOR.x from npm; falling back to pnpm@$PNPM_MAJOR"
-        pnpm_version="$PNPM_MAJOR"
+        log_detail "Could not resolve latest pnpm $PNPM_TARGET_MAJOR.x from npm; falling back to pnpm@$PNPM_TARGET_MAJOR"
+        pnpm_version="$PNPM_TARGET_MAJOR"
     fi
     log_detail "Preparing pnpm@$pnpm_version via corepack..."
     corepack prepare "pnpm@$pnpm_version" --activate

--- a/tools/setup_node.sh
+++ b/tools/setup_node.sh
@@ -31,6 +31,26 @@ get_latest_nvm_version() {
     fi
 }
 
+# Minimum supported pnpm major version. Corepack's bundled `@latest` lags
+# behind npm (it ships a hardcoded "known good" map per Node release), so we
+# resolve the actual latest in this major line from the npm registry.
+PNPM_MAJOR=11
+
+get_latest_pnpm_version() {
+    local major="$1"
+    local version=""
+    if command -v jq &> /dev/null; then
+        version=$(curl -s "https://registry.npmjs.org/-/package/pnpm/dist-tags" | jq -r ".\"latest-$major\"")
+    else
+        version=$(curl -s "https://registry.npmjs.org/-/package/pnpm/dist-tags" | grep -Po "\"latest-$major\"\s*:\s*\"\K[^\"]+")
+    fi
+    if [ -z "$version" ] || [ "$version" = "null" ]; then
+        echo ""
+    else
+        echo "$version"
+    fi
+}
+
 ensure_pnpm() {
     if ! command -v corepack &> /dev/null; then
         log_error "corepack not found — it ships with Node 16.9+. Check your node installation."
@@ -38,8 +58,15 @@ ensure_pnpm() {
     fi
     log_step "Enabling corepack for pnpm..."
     corepack enable
-    log_detail "Preparing pnpm@latest via corepack..."
-    corepack prepare pnpm@latest --activate
+
+    local pnpm_version
+    pnpm_version=$(get_latest_pnpm_version "$PNPM_MAJOR")
+    if [ -z "$pnpm_version" ]; then
+        log_detail "Could not resolve latest pnpm $PNPM_MAJOR.x from npm; falling back to pnpm@$PNPM_MAJOR"
+        pnpm_version="$PNPM_MAJOR"
+    fi
+    log_detail "Preparing pnpm@$pnpm_version via corepack..."
+    corepack prepare "pnpm@$pnpm_version" --activate
 }
 
 ensure_typescript() {


### PR DESCRIPTION
Combines what was originally split across #18 and #19. #18 is being closed in favor of this PR — both changes are needed to make pnpm actually usable on a fresh dotfiles install.

## Summary

**Pin pnpm to the latest 11.x** (`tools/setup_node.sh`, `test/run-test.sh`)
- Resolve the latest `pnpm` 11.x from npm's `latest-11` dist-tag and pass that exact version (e.g. `pnpm@11.1.2`) to `corepack prepare --activate`, with a fallback to `pnpm@11` if the registry call fails.
- New smoke assertion in `test/run-test.sh` that the installed `pnpm` major is `>= 11`.

**Restore `PNPM_HOME` for global installs** (`bash/tool_configs/node.sh`, `bash/bashrc`, `tools/setup_node.sh`)
- PR #12 removed `PNPM_HOME` on the assumption that the corepack shim made it redundant. The shim only handles the `pnpm` binary — `PNPM_HOME` is the install location for **global** packages (`pnpm add -g`, `pnpm dlx` shims), and pnpm refuses global installs without it set and on PATH.
- Without it, `pnpm` prompts the user to run `pnpm setup`, which appends an export block to `~/.bashrc`. Since `~/.bashrc` is a symlink into this repo, that band-aid mutates the dotfiles in the wrong spot (raw bashrc instead of the modular `tool_configs/node.sh`).
- Restore `PNPM_HOME` + PATH entry in `bash/tool_configs/node.sh` with a comment explaining the corepack-vs-PNPM_HOME distinction so this isn't deleted again.
- `tools/setup_node.sh` `mkdir -p "$PNPM_HOME"` so a fresh box never needs interactive `pnpm setup`.
- Drop the stray trailing blank line in `bash/bashrc` that `pnpm setup` previously left behind.

## Why

Corepack bundles a hardcoded "known good" version map per Node release. On Node 24, `corepack prepare pnpm@latest --activate` was resolving to **pnpm 10.28.2** even though pnpm **11.1.2** is the actual latest on npm. Pinning through `latest-11` keeps us on the current major without relying on whatever Node ships in its corepack snapshot.

Separately, removing `PNPM_HOME` broke `pnpm add -g` and caused pnpm to mutate `~/.bashrc` (which is a symlink into this repo). Restoring it in the right place (`tool_configs/node.sh`) closes both issues.

## Test plan

- [x] `bash -n` on all four modified files
- [ ] `./test/run-test.sh` (Docker smoke: install runs end-to-end, `pnpm is 11+` check passes)
- [ ] Sourcing `bash/tool_configs/node.sh` in a clean subshell exports `PNPM_HOME`, puts it on `PATH`, and `pnpm -v` resolves
- [ ] Manual: on a host with a stale corepack-bundled pnpm, re-run `tools/setup_node.sh` and confirm `pnpm --version` reports 11.x, and that `pnpm add -g <pkg>` works without an interactive `pnpm setup` prompt
